### PR TITLE
feat: add HTML artifact preview for inline and file-based HTML outputs

### DIFF
--- a/backend/scripts/askpass-main.ts
+++ b/backend/scripts/askpass-main.ts
@@ -5,6 +5,8 @@ import fs from 'fs'
 interface AskpassRequest {
   askpassType: 'https' | 'ssh'
   argv: string[]
+  cwd?: string
+  repoId?: number
 }
 
 function fatal(err: unknown): never {
@@ -86,7 +88,13 @@ function main(argv: string[]): void {
     process.exit(1)
   })
 
-  const requestPayload: AskpassRequest = { askpassType, argv }
+  const repoId = process.env['OCM_GIT_REPO_ID'] ? Number(process.env['OCM_GIT_REPO_ID']) : undefined
+  const requestPayload: AskpassRequest = {
+    askpassType,
+    argv,
+    cwd: process.env['OCM_GIT_REPO_CWD'],
+    repoId: Number.isFinite(repoId) ? repoId : undefined,
+  }
   console.error('[askpass-main] Sending request:', JSON.stringify(requestPayload))
   req.write(JSON.stringify(requestPayload))
   req.end()

--- a/backend/src/db/queries.ts
+++ b/backend/src/db/queries.ts
@@ -21,6 +21,8 @@ interface RepoRow {
   is_local?: number
 }
 
+const REPO_GIT_CREDENTIAL_SETTING_KEY = 'gitCredentialId'
+
 function rowToRepo(row: RepoRow): Repo {
   const fullPath = row.source_path || path.join(getReposPath(), row.local_path)
 
@@ -40,6 +42,55 @@ function rowToRepo(row: RepoRow): Repo {
     isWorktree: row.is_worktree ? Boolean(row.is_worktree) : undefined,
     isLocal: row.is_local ? Boolean(row.is_local) : undefined,
   }
+}
+
+export function getRepoSetting(db: Database, repoId: number, key: string): string | null {
+  const row = db
+    .prepare('SELECT value FROM repo_settings WHERE repo_id = ? AND key = ?')
+    .get(repoId, key) as { value: string } | undefined
+
+  return row?.value ?? null
+}
+
+export function setRepoSetting(db: Database, repoId: number, key: string, value: string | null): void {
+  const now = Date.now()
+  const updateSetting = db.transaction(() => {
+    if (value === null || value === '') {
+      db.prepare('DELETE FROM repo_settings WHERE repo_id = ? AND key = ?').run(repoId, key)
+      return
+    }
+
+    db.prepare(`
+      INSERT INTO repo_settings (repo_id, key, value, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(repo_id, key) DO UPDATE SET
+        value = excluded.value,
+        updated_at = excluded.updated_at
+    `).run(repoId, key, value, now)
+  })
+
+  updateSetting()
+}
+
+export function getRepoGitCredentialId(db: Database, repoId: number): string | null {
+  return getRepoSetting(db, repoId, REPO_GIT_CREDENTIAL_SETTING_KEY)
+}
+
+export function setRepoGitCredentialId(db: Database, repoId: number, credentialId: string | null): void {
+  setRepoSetting(db, repoId, REPO_GIT_CREDENTIAL_SETTING_KEY, credentialId)
+}
+
+export function getRepoByDirectory(db: Database, directory: string): Repo | null {
+  const resolvedDirectory = path.resolve(directory)
+  const repos = listRepos(db)
+
+  return repos
+    .filter((repo) => {
+      const resolvedRepoPath = path.resolve(repo.fullPath)
+      const relativePath = path.relative(resolvedRepoPath, resolvedDirectory)
+      return relativePath === '' || (!!relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+    })
+    .sort((a, b) => b.fullPath.length - a.fullPath.length)[0] ?? null
 }
 
 const TABLES_WITH_REPO_ID = ['schedule_jobs', 'schedule_runs', 'repo_settings'] as const

--- a/backend/src/ipc/askpassHandler.ts
+++ b/backend/src/ipc/askpassHandler.ts
@@ -1,9 +1,7 @@
 import * as path from 'path'
 import { fileURLToPath } from 'url'
 import type { IPCServer, IPCHandler } from './ipcServer'
-import type { Database } from 'bun:sqlite'
-import { SettingsService } from '../services/settings'
-import type { GitCredential } from '@opencode-manager/shared'
+import { CredentialProvider } from '../services/credential-provider'
 import { logger } from '../utils/logger'
 
 const __filename = fileURLToPath(import.meta.url)
@@ -17,6 +15,8 @@ interface Credentials {
 interface AskpassRequest {
   askpassType: 'https' | 'ssh'
   argv: string[]
+  cwd?: string
+  repoId?: number
 }
 
 export class AskpassHandler implements IPCHandler {
@@ -25,7 +25,7 @@ export class AskpassHandler implements IPCHandler {
 
   constructor(
     private ipcServer: IPCServer | undefined,
-    private database: Database
+    private credentialProvider: CredentialProvider
   ) {
     const scriptsDir = path.join(__dirname, '../../scripts')
 
@@ -49,13 +49,14 @@ export class AskpassHandler implements IPCHandler {
   async handle(request: AskpassRequest): Promise<string> {
     logger.info(`Askpass request received: type=${request.askpassType}, argv=${JSON.stringify(request.argv)}`)
     if (request.askpassType === 'https') {
-      return this.handleHttpsAskpass(request.argv)
+      return this.handleHttpsAskpass(request)
     }
     return this.handleSshAskpass()
   }
 
-  private async handleHttpsAskpass(argv: string[]): Promise<string> {
-    const request = argv[2] || ''
+  private async handleHttpsAskpass(request: AskpassRequest): Promise<string> {
+    const { argv } = request
+    const prompt = argv[2] || ''
     const host = argv[4]?.replace(/^["']+|["':]+$/g, '') || ''
 
     let authority = ''
@@ -66,18 +67,22 @@ export class AskpassHandler implements IPCHandler {
       authority = host
     }
 
-    const isPassword = /password/i.test(request)
+    const isPassword = /password/i.test(prompt)
 
-    const cached = this.cache.get(authority)
+    const cacheKey = `${authority}:${request.repoId ?? ''}:${request.cwd ?? ''}`
+    const cached = this.cache.get(cacheKey)
     if (cached && isPassword) {
-      this.cache.delete(authority)
+      this.cache.delete(cacheKey)
       return cached.password
     }
 
-    const credentials = await this.getCredentialsForHost(authority)
+    const credentials = this.credentialProvider.getPatCredentialForHost(authority, {
+      cwd: request.cwd,
+      repoId: request.repoId,
+    })
     if (credentials) {
-      this.cache.set(authority, credentials)
-      setTimeout(() => this.cache.delete(authority), 60_000)
+      this.cache.set(cacheKey, credentials)
+      setTimeout(() => this.cache.delete(cacheKey), 60_000)
       return isPassword ? credentials.password : credentials.username
     }
 
@@ -86,71 +91,6 @@ export class AskpassHandler implements IPCHandler {
 
   private async handleSshAskpass(): Promise<string> {
     return ''
-  }
-
-  private normalizeHostname(host: string): string {
-    let normalized = host.toLowerCase().trim()
-    normalized = normalized.replace(/\/+$/, '')
-    
-    if (!normalized.includes('://')) {
-      normalized = 'https://' + normalized
-    }
-    
-    try {
-      const parsed = new URL(normalized)
-      return parsed.hostname
-    } catch {
-      const stripped = normalized.replace(/^https?:\/\//, '')
-      return stripped.split('/')[0] || stripped
-    }
-  }
-
-  private async getCredentialsForHost(hostname: string): Promise<Credentials | null> {
-    const normalizedRequest = this.normalizeHostname(hostname)
-    logger.info(`Looking up credentials for host: ${hostname} (normalized: ${normalizedRequest})`)
-    
-    const settingsService = new SettingsService(this.database)
-    const settings = settingsService.getSettings('default')
-    const allCredentials = (settings.preferences.gitCredentials || []) as GitCredential[]
-    const gitCredentials = allCredentials.filter(cred => !cred.type || cred.type === 'pat')
-    logger.info(`Found ${gitCredentials.length} configured PAT credentials (${allCredentials.length} total)`)
-
-    for (const cred of gitCredentials) {
-      const normalizedCred = this.normalizeHostname(cred.host)
-      logger.debug(`Comparing: request='${normalizedRequest}' vs stored='${normalizedCred}' (raw: ${cred.host})`)
-      
-      if (normalizedCred === normalizedRequest) {
-        logger.info(`Found matching PAT credential '${cred.name}' for ${hostname}`)
-        return {
-          username: cred.username || this.getDefaultUsername(cred.host),
-          password: cred.token || '',
-        }
-      }
-    }
-    
-    if (gitCredentials.length > 0) {
-      logger.warn(`No credentials found for host: ${hostname}. Configured hosts: ${gitCredentials.map(c => c.host).join(', ')}`)
-    } else {
-      logger.warn(`No credentials found for host: ${hostname}. No git credentials configured.`)
-    }
-    return null
-  }
-
-  private getDefaultUsername(host: string): string {
-    try {
-      const parsed = new URL(host)
-      const hostname = parsed.hostname.toLowerCase()
-
-      if (hostname === 'github.com') {
-        return 'x-access-token'
-      }
-      if (hostname === 'gitlab.com' || hostname.includes('gitlab')) {
-        return 'oauth2'
-      }
-      return 'oauth2'
-    } catch {
-      return 'oauth2'
-    }
   }
 
   getEnv(): Record<string, string> {

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -23,11 +23,102 @@ function getSpecialRoutePathFromRequest(c: Context, routeName: string): string |
   return match?.[1] ? decodeFilePath(match[1]) : undefined
 }
 
+function getPreviewPathFromRequest(c: Context): string | undefined {
+  const path = c.req.path
+  const prefix = '/api/files/preview'
+
+  const queryPath = c.req.query('path')
+  if (queryPath !== undefined) {
+    return queryPath
+  }
+
+  if (path.startsWith(prefix + '/')) {
+    const previewPath = path.slice(prefix.length + 1)
+    return decodeURIComponent(previewPath)
+  }
+
+  return undefined
+}
+
+const PREVIEWABLE_MIME_TYPES = new Set([
+  'text/html',
+  'text/css',
+  'text/javascript',
+  'application/javascript',
+  'application/json',
+  'application/xml',
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/svg+xml',
+])
+
+function isPreviewableMimeType(mimeType?: string): boolean {
+  return mimeType !== undefined && PREVIEWABLE_MIME_TYPES.has(mimeType)
+}
+
+function getPreviewHeaders(result: { name: string; size: number; mimeType?: string }): Record<string, string> {
+  const isHtmlSvg = result.mimeType === 'text/html' || result.mimeType === 'image/svg+xml'
+  const headers: Record<string, string> = {
+    'Content-Type': result.mimeType || 'application/octet-stream',
+    'Content-Length': result.size.toString(),
+    'Content-Disposition': `inline; filename="${result.name}"`,
+    'X-Content-Type-Options': 'nosniff',
+    'Referrer-Policy': 'no-referrer',
+  }
+
+  if (isHtmlSvg) {
+    headers['Content-Security-Policy'] = [
+      'sandbox allow-scripts;',
+      "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval';",
+      "script-src 'self' http: https: 'unsafe-inline' 'unsafe-eval';",
+      "style-src 'self' http: https: 'unsafe-inline';",
+      "img-src 'self' http: https: data: blob:;",
+      "font-src 'self' http: https: data:;",
+      "connect-src 'self' http: https:;",
+      "media-src 'self' http: https: data: blob:;",
+      "object-src 'none';",
+      "base-uri 'none';",
+      "frame-ancestors 'self'",
+    ].join(' ')
+  }
+
+  return headers
+}
+
 export function createFileRoutes() {
   const app = new Hono()
 
   app.get('*', async (c) => {
     const path = c.req.path
+
+    if (path === '/api/files/preview' || path.startsWith('/api/files/preview/')) {
+      const userPath = getPreviewPathFromRequest(c)
+
+      if (!userPath) {
+        return c.json({ error: 'No path provided' }, 400)
+      }
+
+      try {
+        const result = await fileService.getFile(userPath)
+
+        if (result.isDirectory) {
+          return c.json({ error: 'Cannot preview directories' }, 400)
+        }
+
+        if (!isPreviewableMimeType(result.mimeType)) {
+          return c.json({ error: 'File type cannot be previewed' }, 415)
+        }
+
+        const content = await fileService.getRawFileContent(userPath)
+        const headers = getPreviewHeaders(result)
+
+        return new Response(content, { headers })
+      } catch (error: unknown) {
+        logger.error('Failed to preview file:', error)
+        return c.json({ error: getErrorMessage(error) || 'Failed to preview file' }, getStatusCode(error) as ContentfulStatusCode)
+      }
+    }
 
     if (path.endsWith('/download-zip')) {
       const userPath = getSpecialRoutePathFromRequest(c, 'download-zip')

--- a/backend/src/routes/files.ts
+++ b/backend/src/routes/files.ts
@@ -57,19 +57,50 @@ function isPreviewableMimeType(mimeType?: string): boolean {
   return mimeType !== undefined && PREVIEWABLE_MIME_TYPES.has(mimeType)
 }
 
-function getPreviewHeaders(result: { name: string; size: number; mimeType?: string }): Record<string, string> {
+function buildPreviewValidators(stat: { size: number; lastModified: Date }): { etag: string; lastModified: string } {
+  return {
+    etag: `"${stat.size.toString(16)}-${stat.lastModified.getTime().toString(16)}"`,
+    lastModified: stat.lastModified.toUTCString(),
+  }
+}
+
+function isPreviewFresh(c: Context, validators: { etag: string; lastModified: string }): boolean {
+  const ifNoneMatch = c.req.header('if-none-match')
+  if (ifNoneMatch !== undefined) {
+    return ifNoneMatch.split(',').some((tag: string) => tag.trim() === validators.etag)
+  }
+
+  const ifModifiedSince = c.req.header('if-modified-since')
+  if (ifModifiedSince !== undefined) {
+    const since = Date.parse(ifModifiedSince)
+    return !Number.isNaN(since) && Date.parse(validators.lastModified) <= since
+  }
+
+  return false
+}
+
+function getPreviewHeaders(result: {
+  name: string
+  size: number
+  mimeType?: string
+  lastModified: Date
+}): Record<string, string> {
   const isHtmlSvg = result.mimeType === 'text/html' || result.mimeType === 'image/svg+xml'
+  const validators = buildPreviewValidators(result)
   const headers: Record<string, string> = {
     'Content-Type': result.mimeType || 'application/octet-stream',
     'Content-Length': result.size.toString(),
     'Content-Disposition': `inline; filename="${result.name}"`,
     'X-Content-Type-Options': 'nosniff',
     'Referrer-Policy': 'no-referrer',
+    'Cache-Control': 'private, must-revalidate, max-age=0',
+    'ETag': validators.etag,
+    'Last-Modified': validators.lastModified,
   }
 
   if (isHtmlSvg) {
     headers['Content-Security-Policy'] = [
-      'sandbox allow-scripts;',
+      'sandbox allow-scripts allow-same-origin;',
       "default-src 'self' http: https: data: blob: 'unsafe-inline' 'unsafe-eval';",
       "script-src 'self' http: https: 'unsafe-inline' 'unsafe-eval';",
       "style-src 'self' http: https: 'unsafe-inline';",
@@ -100,18 +131,23 @@ export function createFileRoutes() {
       }
 
       try {
-        const result = await fileService.getFile(userPath)
+        const stat = await fileService.getFilePreviewStat(userPath)
 
-        if (result.isDirectory) {
+        if (stat.isDirectory) {
           return c.json({ error: 'Cannot preview directories' }, 400)
         }
 
-        if (!isPreviewableMimeType(result.mimeType)) {
+        if (!isPreviewableMimeType(stat.mimeType)) {
           return c.json({ error: 'File type cannot be previewed' }, 415)
         }
 
+        const headers = getPreviewHeaders(stat)
+
+        if (isPreviewFresh(c, buildPreviewValidators(stat))) {
+          return new Response(null, { status: 304, headers })
+        }
+
         const content = await fileService.getRawFileContent(userPath)
-        const headers = getPreviewHeaders(result)
 
         return new Response(content, { headers })
       } catch (error: unknown) {

--- a/backend/src/routes/internal/git-credentials.ts
+++ b/backend/src/routes/internal/git-credentials.ts
@@ -1,0 +1,14 @@
+import { Hono } from 'hono'
+import type { Database } from 'bun:sqlite'
+import { CredentialProvider } from '../../services/credential-provider'
+
+export function createInternalGitCredentialsRoutes(db: Database) {
+  const app = new Hono()
+
+  app.get('/gh-env', (c) => {
+    const provider = new CredentialProvider(db)
+    return c.json(provider.getGhCliEnv({ cwd: c.req.query('cwd') }))
+  })
+
+  return app
+}

--- a/backend/src/routes/internal/index.ts
+++ b/backend/src/routes/internal/index.ts
@@ -13,6 +13,7 @@ import { createInternalRepoSyncRoutes } from './repo-sync'
 import { createInternalRepoMirrorRoutes as mirrorRoutes } from './repo-mirror'
 import { createInternalOpenCodeWorkspacesRoutes } from './opencode-workspaces'
 import { createInternalAssistantRoutes } from './assistant'
+import { createInternalGitCredentialsRoutes } from './git-credentials'
 
 export function createInternalRoutes(
   db: Database,
@@ -34,5 +35,6 @@ export function createInternalRoutes(
   app.route('/repos', repos)
   app.route('/opencode-workspaces', createInternalOpenCodeWorkspacesRoutes(db))
   app.route('/assistant', createInternalAssistantRoutes(openCodeClient))
+  app.route('/git-credentials', createInternalGitCredentialsRoutes(db))
   return app
 }

--- a/backend/src/routes/repo-git.ts
+++ b/backend/src/routes/repo-git.ts
@@ -7,12 +7,14 @@ import { parseGitError } from '../utils/git-errors'
 import { GitService } from '../services/git/GitService'
 import type { GitAuthService } from '../services/git-auth'
 import { SettingsService } from '../services/settings'
+import { CredentialProvider } from '../services/credential-provider'
 import type { GitStatusResponse } from '../types/git'
 
 export function createRepoGitRoutes(database: Database, gitAuthService: GitAuthService) {
   const app = new Hono()
   const settingsService = new SettingsService(database)
-  const git = new GitService(gitAuthService, settingsService)
+  const credentialProvider = new CredentialProvider(database)
+  const git = new GitService(gitAuthService, settingsService, credentialProvider)
 
   app.get('/:id/git/status', async (c) => {
     try {

--- a/backend/src/routes/repos.ts
+++ b/backend/src/routes/repos.ts
@@ -3,7 +3,7 @@ import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import type { Database } from 'bun:sqlite'
 import type { Repo } from '@opencode-manager/shared/types'
 import { DiscoverReposRequestSchema, AssistantModeInitRequestSchema } from '@opencode-manager/shared/schemas'
-import { listRepos, getRepoById, updateLastAccessed, updateRepoConfigName } from '../db/queries'
+import { listRepos, getRepoById, updateLastAccessed, updateRepoConfigName, getRepoGitCredentialId, setRepoGitCredentialId } from '../db/queries'
 import * as repoService from '../services/repo'
 import * as archiveService from '../services/archive'
 import { SettingsService } from '../services/settings'
@@ -34,6 +34,13 @@ async function restartOpenCode(openCodeSupervisor?: OpenCodeSupervisor): Promise
 
 function resolveRepo(database: Database, id: number): Repo | null {
   return getRepoById(database, id) ?? (id === ASSISTANT_REPO_ID ? buildAssistantRepo() : null)
+}
+
+function withRepoSettings(database: Database, repo: Repo): Repo {
+  return {
+    ...repo,
+    gitCredentialId: getRepoGitCredentialId(database, repo.id) ?? undefined,
+  }
 }
 
 export function createRepoRoutes(
@@ -128,7 +135,7 @@ app.get('/', async (c) => {
         repos.map(async (repo) => {
           const env = gitAuthService.getGitEnvironment()
           const currentBranch = repo.id === ASSISTANT_REPO_ID ? undefined : await repoService.getCurrentBranch(repo, env)
-          return { ...repo, currentBranch }
+          return { ...withRepoSettings(database, repo), currentBranch }
         })
       )
       return c.json(reposWithCurrentBranch)
@@ -170,7 +177,7 @@ app.get('/', async (c) => {
       
       const currentBranch = id === ASSISTANT_REPO_ID ? undefined : await repoService.getCurrentBranch(repo, gitAuthService.getGitEnvironment())
       
-      return c.json({ ...repo, currentBranch })
+      return c.json({ ...withRepoSettings(database, repo), currentBranch })
     } catch (error: unknown) {
       logger.error('Failed to get repo:', error)
       return c.json({ error: getErrorMessage(error) }, 500)
@@ -208,6 +215,36 @@ app.get('/', async (c) => {
       return c.json({ success: true })
     } catch (error: unknown) {
       logger.error('Failed to update repo access:', error)
+      return c.json({ error: getErrorMessage(error) }, 500)
+    }
+  })
+
+  app.patch('/:id/git-credential', async (c) => {
+    try {
+      const id = parseInt(c.req.param('id'))
+      const repo = getRepoById(database, id)
+
+      if (!repo) {
+        return c.json({ error: 'Repo not found' }, 404)
+      }
+
+      const body = await c.req.json()
+      const credentialId = typeof body.credentialId === 'string' && body.credentialId.trim() !== ''
+        ? body.credentialId.trim()
+        : null
+
+      if (credentialId) {
+        const settingsService = new SettingsService(database)
+        const settings = settingsService.getSettings()
+        if (!(settings.preferences.gitCredentials || []).some((credential) => credential.id === credentialId)) {
+          return c.json({ error: 'Credential not found' }, 400)
+        }
+      }
+
+      setRepoGitCredentialId(database, id, credentialId)
+      return c.json(withRepoSettings(database, repo))
+    } catch (error: unknown) {
+      logger.error('Failed to update repo git credential:', error)
       return c.json({ error: getErrorMessage(error) }, 500)
     }
   })

--- a/backend/src/routes/settings.ts
+++ b/backend/src/routes/settings.ts
@@ -1,6 +1,7 @@
 import { Hono, type Context } from 'hono'
 import { z } from 'zod'
 import { execSync, spawnSync } from 'child_process'
+import { randomUUID } from 'crypto'
 import { existsSync } from 'fs'
 import { resolve, dirname } from 'path'
 import type { Database } from 'bun:sqlite'
@@ -394,6 +395,7 @@ export function createSettingsRoutes(db: Database, gitAuthService: GitAuthServic
 
               const result: GitCredential = {
                 ...cred,
+                id: cred.id || randomUUID(),
                 sshPrivateKeyEncrypted: encryptSecret(cred.sshPrivateKey),
                 hasPassphrase: validation.hasPassphrase,
                 passphrase: cred.passphrase ? encryptSecret(cred.passphrase) : undefined,
@@ -401,10 +403,13 @@ export function createSettingsRoutes(db: Database, gitAuthService: GitAuthServic
               delete result.sshPrivateKey
               return result
             }
-            return cred
+            return { ...cred, id: cred.id || randomUUID() }
           })
         )
         validated.preferences.gitCredentials = validations
+        if (validated.preferences.defaultGitCredentialId && !validations.some((cred) => cred.id === validated.preferences.defaultGitCredentialId)) {
+          validated.preferences.defaultGitCredentialId = undefined
+        }
       }
 
       const currentSettings = settingsService.getSettings(userId)

--- a/backend/src/services/credential-provider.ts
+++ b/backend/src/services/credential-provider.ts
@@ -1,0 +1,89 @@
+import type { Database } from 'bun:sqlite'
+import type { GitCredential } from '@opencode-manager/shared'
+import { SettingsService } from './settings'
+import {
+  findPatCredentialForHost,
+  getSSHCredentialsForHost,
+  createGitEnv,
+  findGitHubCredential,
+  type ResolvedGitCredential,
+} from '../utils/git-auth'
+import { getRepoByDirectory, getRepoGitCredentialId } from '../db/queries'
+
+interface CredentialResolutionOptions {
+  cwd?: string
+  repoId?: number
+}
+
+export class CredentialProvider {
+  private settingsService: SettingsService
+  private database: Database
+
+  constructor(database: Database) {
+    this.database = database
+    this.settingsService = new SettingsService(database)
+  }
+
+  getGitCredentials(): GitCredential[] {
+    const settings = this.settingsService.getSettings('default')
+    return (settings.preferences.gitCredentials || []) as GitCredential[]
+  }
+
+  getGitCredentialById(credentialId: string | undefined): GitCredential | null {
+    if (!credentialId) return null
+    return this.getGitCredentials().find((credential) => credential.id === credentialId) ?? null
+  }
+
+  getPatCredentialForHost(hostname: string, options: CredentialResolutionOptions = {}): ResolvedGitCredential | null {
+    const credentials = this.getGitCredentials()
+    const selectedCredential = this.getSelectedCredential(options, credentials)
+    const selectedMatch = selectedCredential ? findPatCredentialForHost([selectedCredential], hostname) : null
+    return selectedMatch ?? findPatCredentialForHost(credentials, hostname)
+  }
+
+  getSshCredentialsForHost(host: string): GitCredential[] {
+    return getSSHCredentialsForHost(this.getGitCredentials(), host)
+  }
+
+  getSshCredentialsWithPrivateKey(): GitCredential[] {
+    return this.getGitCredentials().filter((cred) => cred.type === 'ssh' && cred.sshPrivateKeyEncrypted)
+  }
+
+  getGitEnv(): Record<string, string> {
+    return createGitEnv(this.getGitCredentials())
+  }
+
+  getGhCliEnv(options: CredentialResolutionOptions = {}): Record<string, string> {
+    const credential = this.getGhCliCredential(options)
+    if (!credential?.token) return {}
+    return { GH_TOKEN: credential.token, GITHUB_TOKEN: credential.token }
+  }
+
+  private getGhCliCredential(options: CredentialResolutionOptions): GitCredential | null {
+    const credentials = this.getGitCredentials()
+    const selectedCredential = this.getSelectedCredential(options, credentials)
+    if (this.isGithubPatCredential(selectedCredential)) return selectedCredential
+
+    return findGitHubCredential(credentials)
+  }
+
+  private getSelectedCredential(options: CredentialResolutionOptions, credentials: GitCredential[]): GitCredential | null {
+    const repoCredential = this.getRepoCredential(options, credentials)
+    if (repoCredential) return repoCredential
+
+    const settings = this.settingsService.getSettings('default')
+    return credentials.find((credential) => credential.id === settings.preferences.defaultGitCredentialId) ?? null
+  }
+
+  private getRepoCredential(options: CredentialResolutionOptions, credentials: GitCredential[]): GitCredential | null {
+    const repoId = options.repoId ?? (options.cwd ? getRepoByDirectory(this.database, options.cwd)?.id : undefined)
+    if (!repoId) return null
+
+    const credentialId = getRepoGitCredentialId(this.database, repoId)
+    return credentials.find((credential) => credential.id === credentialId) ?? null
+  }
+
+  private isGithubPatCredential(credential: GitCredential | null): credential is GitCredential {
+    return !!credential && credential.type !== 'ssh' && findGitHubCredential([credential]) === credential
+  }
+}

--- a/backend/src/services/files.ts
+++ b/backend/src/services/files.ts
@@ -61,6 +61,33 @@ export async function getRawFileContent(userPath: string): Promise<Buffer> {
   }
 }
 
+export interface FilePreviewStat {
+  isDirectory: boolean
+  name: string
+  size: number
+  mimeType: string
+  lastModified: Date
+}
+
+export async function getFilePreviewStat(userPath: string): Promise<FilePreviewStat> {
+  const validatedPath = validatePath(userPath)
+
+  const exists = await fileExists(validatedPath)
+  if (!exists) {
+    throw { message: 'File not found or cannot be read', statusCode: 404 }
+  }
+
+  const stats = await getFileStats(validatedPath)
+
+  return {
+    isDirectory: stats.isDirectory,
+    name: path.basename(validatedPath),
+    size: stats.size,
+    mimeType: getMimeType(validatedPath),
+    lastModified: stats.lastModified,
+  }
+}
+
 export async function getFile(userPath: string): Promise<FileInfo> {
   const validatedPath = validatePath(userPath)
   logger.info(`Getting file for path: ${userPath} -> ${validatedPath}`)

--- a/backend/src/services/files.ts
+++ b/backend/src/services/files.ts
@@ -253,6 +253,7 @@ function getMimeType(filePath: string): AllowedMimeType {
   const mimeTypes: Record<string, AllowedMimeType> = {
     '.txt': 'text/plain',
     '.html': 'text/html',
+    '.htm': 'text/html',
     '.css': 'text/css',
     '.js': 'text/javascript',
     '.ts': 'text/typescript',

--- a/backend/src/services/git-auth.ts
+++ b/backend/src/services/git-auth.ts
@@ -4,10 +4,10 @@ import { AskpassHandler } from '../ipc/askpassHandler'
 import { SSHHostKeyHandler } from '../ipc/sshHostKeyHandler'
 import { writeTemporarySSHKey, buildSSHCommand, buildSSHCommandWithKnownHosts, cleanupSSHKey, parseSSHHost } from '../utils/ssh-key-manager'
 import { decryptSecret } from '../utils/crypto'
-import { isSSHUrl, normalizeSSHUrl, extractHostFromSSHUrl, getSSHCredentialsForHost } from '../utils/git-auth'
+import { isSSHUrl, normalizeSSHUrl, extractHostFromSSHUrl } from '../utils/git-auth'
 import type { GitCredential } from '@opencode-manager/shared'
 import { logger } from '../utils/logger'
-import { SettingsService } from './settings'
+import { CredentialProvider } from './credential-provider'
 
 export class GitAuthService {
   private askpassHandler: AskpassHandler | null = null
@@ -15,9 +15,11 @@ export class GitAuthService {
   private sshKeyPath: string | null = null
   private sshPassphrase: string | null = null
   private sshPort: string | null = null
+  private credentialProvider: CredentialProvider | null = null
 
   async initialize(ipcServer: IPCServer | undefined, database: Database): Promise<void> {
-    this.askpassHandler = new AskpassHandler(ipcServer, database)
+    this.credentialProvider = new CredentialProvider(database)
+    this.askpassHandler = new AskpassHandler(ipcServer, this.credentialProvider)
     this.sshHostKeyHandler = new SSHHostKeyHandler(database, 120_000)
     await this.sshHostKeyHandler.initialize()
 
@@ -97,10 +99,7 @@ export class GitAuthService {
     const { port } = parseSSHHost(normalizedUrl)
     this.setSSHPort(port && port !== '22' ? port : null)
 
-    const settingsService = new SettingsService(database)
-    const settings = settingsService.getSettings('default')
-    const gitCredentials = (settings.preferences.gitCredentials || []) as GitCredential[]
-    const sshCredentials = getSSHCredentialsForHost(gitCredentials, sshHost)
+    const sshCredentials = this.credentialProvider!.getSshCredentialsForHost(sshHost)
 
     if (sshCredentials.length > 0 && sshCredentials[0]) {
       try {

--- a/backend/src/services/git/GitService.ts
+++ b/backend/src/services/git/GitService.ts
@@ -6,15 +6,16 @@ import { getRepoById } from '../../db/queries'
 import { resolveGitIdentity, createGitIdentityEnv, isSSHUrl } from '../../utils/git-auth'
 import { isNoUpstreamError, parseBranchNameFromError } from '../../utils/git-errors'
 import { SettingsService } from '../settings'
+import { CredentialProvider } from '../credential-provider'
 import type { Database } from 'bun:sqlite'
 import type { GitBranch, GitCommit, FileDiffResponse, GitDiffOptions, GitStatusResponse, GitFileStatus, GitFileStatusType, CommitDetails, CommitFile } from '../../types/git'
-import type { GitCredential } from '@opencode-manager/shared'
 import path from 'path'
 
 export class GitService {
   constructor(
     private gitAuthService: GitAuthService,
-    private settingsService: SettingsService
+    private settingsService: SettingsService,
+    private credentialProvider: CredentialProvider
   ) {}
 
   async getStatus(repoId: number, database: Database): Promise<GitStatusResponse> {
@@ -196,10 +197,10 @@ export class GitService {
       }
 
       const repoPath = repo.fullPath
-      const authEnv = this.gitAuthService.getGitEnvironment()
+      const authEnv = this.getEnvironmentForRepo(repo)
 
       const settings = this.settingsService.getSettings('default')
-      const gitCredentials = (settings.preferences.gitCredentials || []) as GitCredential[]
+      const gitCredentials = this.credentialProvider.getGitCredentials()
       const identity = await resolveGitIdentity(settings.preferences.gitIdentity, gitCredentials)
       const identityEnv = identity ? createGitIdentityEnv(identity) : {}
 
@@ -523,13 +524,18 @@ export class GitService {
     await this.gitAuthService.cleanupSSHKey()
   }
 
-  private getEnvironmentForRepo(repo: { repoUrl?: string; fullPath: string }, silent: boolean = false): Record<string, string> {
+  private getEnvironmentForRepo(repo: { id?: number; repoUrl?: string; fullPath: string }, silent: boolean = false): Record<string, string> {
+    const repoContextEnv = {
+      ...(repo.id ? { OCM_GIT_REPO_ID: String(repo.id) } : {}),
+      OCM_GIT_REPO_CWD: repo.fullPath,
+    }
+
     if (!repo.repoUrl) {
-      return this.gitAuthService.getGitEnvironment(silent)
+      return { ...this.gitAuthService.getGitEnvironment(silent), ...repoContextEnv }
     }
 
     const isSSH = isSSHUrl(repo.repoUrl)
-    const baseEnv = this.gitAuthService.getGitEnvironment(silent)
+    const baseEnv = { ...this.gitAuthService.getGitEnvironment(silent), ...repoContextEnv }
 
     if (!isSSH) {
       return baseEnv

--- a/backend/src/services/opencode-gh-env-plugin.ts
+++ b/backend/src/services/opencode-gh-env-plugin.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import { logger } from '../utils/logger'
+
+const PLUGIN_FILENAME = 'ocm-gh-env.js'
+
+const PLUGIN_SOURCE = `const TTL_MS = 5000
+let cache = new Map()
+
+async function fetchGhEnv(cwd) {
+  const baseUrl = process.env.OCM_INTERNAL_API_URL
+  const token = process.env.OCM_INTERNAL_TOKEN
+  if (!baseUrl || !token) return {}
+  const now = Date.now()
+  const cacheKey = cwd || ''
+  const cached = cache.get(cacheKey)
+  if (cached && now < cached.expiry) return cached.env
+  try {
+    const url = new URL(baseUrl + '/git-credentials/gh-env')
+    if (cwd) url.searchParams.set('cwd', cwd)
+    const res = await fetch(url, {
+      headers: { Authorization: 'Bearer ' + token },
+    })
+    if (!res.ok) return cached?.env || {}
+    const env = await res.json()
+    const next = { expiry: now + TTL_MS, env: env && typeof env === 'object' ? env : {} }
+    cache.set(cacheKey, next)
+    return next.env
+  } catch {
+    return cached?.env || {}
+  }
+}
+
+export default async function () {
+  return {
+    'shell.env': async (input, output) => {
+      const env = await fetchGhEnv(input.cwd)
+      Object.assign(output.env, env)
+    },
+  }
+}
+`
+
+export function getGhEnvPluginDir(configHome: string): string {
+  return path.join(configHome, 'opencode', 'plugin')
+}
+
+export async function installGhEnvPlugin(configHome: string): Promise<void> {
+  try {
+    const dir = getGhEnvPluginDir(configHome)
+    await fs.mkdir(dir, { recursive: true })
+    await fs.writeFile(path.join(dir, PLUGIN_FILENAME), PLUGIN_SOURCE, 'utf-8')
+  } catch (error) {
+    logger.warn('Failed to install gh-env OpenCode plugin:', error)
+  }
+}

--- a/backend/src/services/opencode-single-server.ts
+++ b/backend/src/services/opencode-single-server.ts
@@ -2,8 +2,7 @@ import { spawn, execSync, spawnSync } from 'child_process'
 import path from 'path'
 import { promises as fs } from 'fs'
 import { logger } from '../utils/logger'
-import { createGitEnv, createGitIdentityEnv, resolveGitIdentity } from '../utils/git-auth'
-import type { GitCredential } from '@opencode-manager/shared'
+import { createGitIdentityEnv, resolveGitIdentity } from '../utils/git-auth'
 import {
   buildSSHCommandWithKnownHosts,
   buildSSHCommandWithConfig,
@@ -24,6 +23,9 @@ import { compareVersions } from '../utils/version-utils'
 import { patchConfigWithRecovery } from './opencode/config-recovery'
 import type { OpenCodeClient } from './opencode/client'
 import { writeFileContent } from './file-operations'
+import { getOrCreateInternalToken } from './internal-token'
+import { installGhEnvPlugin } from './opencode-gh-env-plugin'
+import { CredentialProvider } from './credential-provider'
 
 
 const MIN_OPENCODE_VERSION = '1.0.137'
@@ -202,14 +204,15 @@ class OpenCodeServerManager {
       throw new Error(msg)
     }
 
-    let gitCredentials: GitCredential[] = []
+    let credentialProvider: CredentialProvider | null = null
     let gitIdentityEnv: Record<string, string> = {}
     let userEnvVars: Record<string, string> = {}
     if (this.db) {
       try {
+        credentialProvider = new CredentialProvider(this.db)
         const settingsService = new SettingsService(this.db)
         const settings = settingsService.getSettings('default')
-        gitCredentials = settings.preferences.gitCredentials || []
+        const gitCredentials = credentialProvider.getGitCredentials()
         const disabledDefaultEnvVars = new Set(settings.preferences.disabledDefaultServerEnvVars || [])
         const rawEnvVars = [
           ...DEFAULT_SERVER_ENV_VARS.filter((envVar) => !disabledDefaultEnvVars.has(envVar.key)),
@@ -279,12 +282,12 @@ class OpenCodeServerManager {
     logger.info(`OpenCode XDG_CONFIG_HOME: ${path.join(openCodeServerDirectory, '.config')}`)
     logger.info(`OpenCode will use ?directory= parameter for session isolation`)
 
-    const gitEnv = createGitEnv(gitCredentials)
+    const gitEnv = credentialProvider?.getGitEnv() ?? {}
     const knownHostsPath = path.join(getWorkspacePath(), 'config', 'known_hosts')
     let gitSshCommand: string
     let sshConfigPath: string | null = null
 
-    const sshCredentials = gitCredentials.filter(cred => cred.type === 'ssh' && cred.sshPrivateKeyEncrypted)
+    const sshCredentials = credentialProvider?.getSshCredentialsWithPrivateKey() ?? []
     if (sshCredentials.length > 0) {
       logger.info(`Setting up ${sshCredentials.length} SSH credential(s) for OpenCode server`)
 
@@ -327,6 +330,7 @@ class OpenCodeServerManager {
     logger.info(`OpenCode server GIT_SSH_COMMAND: ${gitSshCommand}`)
 
     await this.initializeOpencodeBinDirectory()
+    await installGhEnvPlugin(path.join(openCodeServerDirectory, '.config'))
     const configuredPlugins = await this.getConfiguredPlugins(openCodeConfigPath)
     await this.installConfiguredPlugins(configuredPlugins)
     const configuredPluginCount = configuredPlugins.length
@@ -352,6 +356,12 @@ class OpenCodeServerManager {
           ...userEnvVars,
           ...gitEnv,
           ...gitIdentityEnv,
+          ...(this.db
+            ? {
+              OCM_INTERNAL_API_URL: `http://localhost:${ENV.SERVER.PORT}/api/internal`,
+              OCM_INTERNAL_TOKEN: getOrCreateInternalToken(this.db),
+            }
+            : {}),
           GIT_SSH_COMMAND: gitSshCommand,
           XDG_DATA_HOME: path.join(openCodeServerDirectory, '.opencode/state'),
           XDG_STATE_HOME: path.join(openCodeServerDirectory, '.opencode/state'),

--- a/backend/src/utils/git-auth.ts
+++ b/backend/src/utils/git-auth.ts
@@ -112,6 +112,36 @@ export function findGitHubCredential(credentials: GitCredential[]): GitCredentia
   }) || null
 }
 
+export function createGhCliEnv(credentials: GitCredential[]): Record<string, string> {
+  const githubCred = findGitHubCredential(credentials)
+  if (!githubCred?.token) return {}
+  return { GH_TOKEN: githubCred.token, GITHUB_TOKEN: githubCred.token }
+}
+
+export interface ResolvedGitCredential {
+  username: string
+  password: string
+}
+
+export function findPatCredentialForHost(
+  credentials: GitCredential[],
+  hostname: string
+): ResolvedGitCredential | null {
+  const target = normalizeGitCredentialUrl(hostname)?.hostname.toLowerCase()
+  if (!target) return null
+  for (const cred of credentials) {
+    if (cred.type && cred.type !== 'pat') continue
+    const credHost = normalizeGitCredentialUrl(cred.host)?.hostname.toLowerCase()
+    if (credHost && credHost === target) {
+      return {
+        username: cred.username || getDefaultUsername(cred.host),
+        password: cred.token || '',
+      }
+    }
+  }
+  return null
+}
+
 export function getSSHCredentialsForHost(credentials: GitCredential[], host: string): GitCredential[] {
   return credentials.filter(cred => {
     if (cred.type !== 'ssh') return false

--- a/backend/test/ipc/askpassHandler.test.ts
+++ b/backend/test/ipc/askpassHandler.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Database } from 'bun:sqlite'
+import { migrate } from '../../src/db/migration-runner'
+import { allMigrations } from '../../src/db/migrations'
+import { SettingsService } from '../../src/services/settings'
+import { CredentialProvider } from '../../src/services/credential-provider'
+import { AskpassHandler } from '../../src/ipc/askpassHandler'
+import { createRepo, setRepoGitCredentialId } from '../../src/db/queries'
+import type { GitCredential } from '@opencode-manager/shared'
+
+function createGitHubPatCredential(token: string = 'ghp_test_token', id?: string): GitCredential {
+  return {
+    ...(id ? { id } : {}),
+    name: 'github-pat',
+    host: 'github.com',
+    type: 'pat' as const,
+    username: 'x-access-token',
+    token,
+  } as GitCredential
+}
+
+describe('AskpassHandler', () => {
+  let db: Database
+  let settingsService: SettingsService
+  let provider: CredentialProvider
+  let handler: AskpassHandler
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    migrate(db, allMigrations)
+    settingsService = new SettingsService(db)
+    settingsService.updateSettings({
+      gitCredentials: [createGitHubPatCredential()],
+    })
+    provider = new CredentialProvider(db)
+    handler = new AskpassHandler(undefined, provider)
+  })
+
+  it('returns username on Username prompt for configured host', async () => {
+    const result = await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Username for 'https://github.com'", '', 'https://github.com'],
+    })
+    expect(result).toBe('x-access-token')
+  })
+
+  it('returns token on Password prompt after Username (cache path)', async () => {
+    // First call to populate cache
+    await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Username for 'https://github.com'", '', 'https://github.com'],
+    })
+
+    // Second call should use cache
+    const result = await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Password for 'https://github.com'", '', 'https://github.com'],
+    })
+    expect(result).toBe('ghp_test_token')
+  })
+
+  it('returns empty string for unknown host', async () => {
+    const result = await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Username for 'https://unknown.example.com'", '', 'https://unknown.example.com'],
+    })
+    expect(result).toBe('')
+  })
+
+  it('returns the repo-specific token for askpass requests with repo cwd', async () => {
+    const defaultCredential = createGitHubPatCredential('default-token', 'default-id')
+    const repoCredential = createGitHubPatCredential('repo-token', 'repo-id')
+    settingsService.updateSettings({
+      gitCredentials: [defaultCredential, repoCredential],
+      defaultGitCredentialId: 'default-id',
+    })
+    const repo = createRepo(db, {
+      repoUrl: 'https://github.com/acme/repo.git',
+      localPath: 'repo',
+      defaultBranch: 'main',
+      cloneStatus: 'ready',
+      clonedAt: Date.now(),
+    })
+    setRepoGitCredentialId(db, repo.id, 'repo-id')
+
+    await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Username for 'https://github.com'", '', 'https://github.com'],
+      cwd: repo.fullPath,
+    })
+    const result = await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Password for 'https://github.com'", '', 'https://github.com'],
+      cwd: repo.fullPath,
+    })
+
+    expect(result).toBe('repo-token')
+  })
+
+  it('keeps askpass cache separate per repo cwd', async () => {
+    const repoOneCredential = createGitHubPatCredential('repo-one-token', 'repo-one-id')
+    const repoTwoCredential = createGitHubPatCredential('repo-two-token', 'repo-two-id')
+    settingsService.updateSettings({ gitCredentials: [repoOneCredential, repoTwoCredential] })
+    const repoOne = createRepo(db, {
+      repoUrl: 'https://github.com/acme/one.git',
+      localPath: 'one',
+      defaultBranch: 'main',
+      cloneStatus: 'ready',
+      clonedAt: Date.now(),
+    })
+    const repoTwo = createRepo(db, {
+      repoUrl: 'https://github.com/acme/two.git',
+      localPath: 'two',
+      defaultBranch: 'main',
+      cloneStatus: 'ready',
+      clonedAt: Date.now(),
+    })
+    setRepoGitCredentialId(db, repoOne.id, 'repo-one-id')
+    setRepoGitCredentialId(db, repoTwo.id, 'repo-two-id')
+
+    await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Username for 'https://github.com'", '', 'https://github.com'],
+      cwd: repoOne.fullPath,
+    })
+    await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Username for 'https://github.com'", '', 'https://github.com'],
+      cwd: repoTwo.fullPath,
+    })
+
+    const repoOnePassword = await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Password for 'https://github.com'", '', 'https://github.com'],
+      cwd: repoOne.fullPath,
+    })
+    const repoTwoPassword = await handler.handle({
+      askpassType: 'https',
+      argv: ['', '', "Password for 'https://github.com'", '', 'https://github.com'],
+      cwd: repoTwo.fullPath,
+    })
+
+    expect(repoOnePassword).toBe('repo-one-token')
+    expect(repoTwoPassword).toBe('repo-two-token')
+  })
+})

--- a/backend/test/mocks/bun-sqlite.ts
+++ b/backend/test/mocks/bun-sqlite.ts
@@ -17,6 +17,10 @@ export class Database {
     }
   }
 
+  query(sql: string) {
+    return this.prepare(sql)
+  }
+
   exec(sql: string) {
     this.db.exec(sql)
   }

--- a/backend/test/routes/files.test.ts
+++ b/backend/test/routes/files.test.ts
@@ -47,6 +47,7 @@ vi.mock('../../src/services/archive', () => ({
 }))
 
 const getFile = fileService.getFile as MockedFunction<typeof fileService.getFile>
+const getRawFileContent = fileService.getRawFileContent as MockedFunction<typeof fileService.getRawFileContent>
 const getFileRange = fileService.getFileRange as MockedFunction<typeof fileService.getFileRange>
 const uploadFile = fileService.uploadFile as MockedFunction<typeof fileService.uploadFile>
 const createFileOrFolder = fileService.createFileOrFolder as MockedFunction<typeof fileService.createFileOrFolder>
@@ -67,6 +68,125 @@ describe('File Routes', () => {
     filesApp = createFileRoutes()
     app = new Hono()
     app.route('/api/files', filesApp)
+  })
+
+  describe('GET /preview/* - HTML Preview Assets', () => {
+    const htmlFileInfo: FileInfo = {
+      name: 'index.html',
+      path: 'test-repo/index.html',
+      isDirectory: false,
+      size: 31,
+      mimeType: 'text/html',
+      content: '',
+      lastModified: new Date(),
+    }
+
+    it('should serve HTML files with sandbox CSP headers', async () => {
+      getFile.mockResolvedValue(htmlFileInfo)
+      getRawFileContent.mockResolvedValue(Buffer.from('<html><body>Hello</body></html>'))
+
+      const response = await app.request('/api/files/preview/test-repo/index.html')
+      const body = await response.text()
+
+      expect(response.status).toBe(200)
+      expect(body).toBe('<html><body>Hello</body></html>')
+      expect(response.headers.get('Content-Type')).toContain('text/html')
+      expect(response.headers.get('Content-Disposition')).toContain('inline')
+      expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
+      expect(response.headers.get('Referrer-Policy')).toBe('no-referrer')
+      expect(response.headers.get('Content-Security-Policy')).toContain('sandbox allow-scripts')
+      expect(response.headers.get('Content-Security-Policy')).toContain('https:')
+      expect(getFile).toHaveBeenCalledWith('test-repo/index.html')
+      expect(getRawFileContent).toHaveBeenCalledWith('test-repo/index.html')
+    })
+
+    it('should serve CSS files with text/css Content-Type', async () => {
+      const cssFileInfo: FileInfo = {
+        name: 'styles.css',
+        path: 'test-repo/styles/app.css',
+        isDirectory: false,
+        size: 50,
+        mimeType: 'text/css',
+        content: '',
+        lastModified: new Date(),
+      }
+      getFile.mockResolvedValue(cssFileInfo)
+      getRawFileContent.mockResolvedValue(Buffer.from('body { color: red }'))
+
+      const response = await app.request('/api/files/preview/test-repo/styles/app.css')
+
+      expect(response.status).toBe(200)
+      expect(response.headers.get('Content-Type')).toContain('text/css')
+      expect(response.headers.get('Content-Security-Policy')).toBeNull()
+      expect(getFile).toHaveBeenCalledWith('test-repo/styles/app.css')
+    })
+
+    it('should support query-based path parameter', async () => {
+      getFile.mockResolvedValue(htmlFileInfo)
+      getRawFileContent.mockResolvedValue(Buffer.from('<html><body>Hello</body></html>'))
+
+      const response = await app.request('/api/files/preview?path=test-repo/index.html')
+      const body = await response.text()
+
+      expect(response.status).toBe(200)
+      expect(body).toBe('<html><body>Hello</body></html>')
+      expect(getFile).toHaveBeenCalledWith('test-repo/index.html')
+    })
+
+    it('should return 400 for directory results', async () => {
+      const dirInfo: FileInfo = {
+        name: 'test-repo',
+        path: 'test-repo',
+        isDirectory: true,
+        size: 0,
+        lastModified: new Date(),
+      }
+      getFile.mockResolvedValue(dirInfo)
+
+      const response = await app.request('/api/files/preview/test-repo')
+
+      expect(response.status).toBe(400)
+      const body = await response.json() as { error: string }
+      expect(body.error).toContain('Cannot preview directories')
+    })
+
+    it('should return 415 for non-previewable MIME types', async () => {
+      const pdfFileInfo: FileInfo = {
+        name: 'doc.pdf',
+        path: 'test-repo/doc.pdf',
+        isDirectory: false,
+        size: 100,
+        mimeType: 'application/pdf',
+        content: '',
+        lastModified: new Date(),
+      }
+      getFile.mockResolvedValue(pdfFileInfo)
+
+      const response = await app.request('/api/files/preview/test-repo/doc.pdf')
+
+      expect(response.status).toBe(415)
+      const body = await response.json() as { error: string }
+      expect(body.error).toContain('File type cannot be previewed')
+    })
+
+    it('should return 400 when no path is provided', async () => {
+      const response = await app.request('/api/files/preview')
+
+      expect(response.status).toBe(400)
+      const body = await response.json() as { error: string }
+      expect(body.error).toContain('No path provided')
+    })
+
+    it('should return 403 for path traversal attempts', async () => {
+      const error = { message: 'Path traversal detected', statusCode: 403 }
+      getFile.mockRejectedValue(error)
+
+      const response = await app.request('/api/files/preview/test-repo/../outside')
+
+      expect(response.status).toBe(403)
+      const body = await response.json() as { error: string }
+      expect(body.error).toContain('Path traversal detected')
+    })
   })
 
   describe('GET /*/download-zip - Route Order Regression Test', () => {
@@ -174,6 +294,17 @@ describe('File Routes', () => {
 
       expect(response.status).toBe(404)
       expect(body).toHaveProperty('error')
+    })
+
+    it('should route paths starting with "preview" but not matching /preview/ to generic handler', async () => {
+      getFile.mockResolvedValue(mockFileInfo)
+
+      const response = await app.request('/api/files/previewer')
+      const body = await response.json() as FileInfo
+
+      expect(response.status).toBe(200)
+      expect(body).toHaveProperty('isDirectory', false)
+      expect(getFile).toHaveBeenCalledWith('previewer')
     })
   })
 

--- a/backend/test/routes/files.test.ts
+++ b/backend/test/routes/files.test.ts
@@ -30,6 +30,7 @@ vi.mock('@opencode-manager/shared/config/env', () => ({
 
 vi.mock('../../src/services/files', () => ({
   getFile: vi.fn(),
+  getFilePreviewStat: vi.fn(),
   getRawFileContent: vi.fn(),
   getFileRange: vi.fn(),
   uploadFile: vi.fn(),
@@ -47,6 +48,7 @@ vi.mock('../../src/services/archive', () => ({
 }))
 
 const getFile = fileService.getFile as MockedFunction<typeof fileService.getFile>
+const getFilePreviewStat = fileService.getFilePreviewStat as MockedFunction<typeof fileService.getFilePreviewStat>
 const getRawFileContent = fileService.getRawFileContent as MockedFunction<typeof fileService.getRawFileContent>
 const getFileRange = fileService.getFileRange as MockedFunction<typeof fileService.getFileRange>
 const uploadFile = fileService.uploadFile as MockedFunction<typeof fileService.uploadFile>
@@ -71,18 +73,18 @@ describe('File Routes', () => {
   })
 
   describe('GET /preview/* - HTML Preview Assets', () => {
-    const htmlFileInfo: FileInfo = {
+    const lastModified = new Date('2024-01-01T00:00:00.000Z')
+
+    const htmlStat = {
       name: 'index.html',
-      path: 'test-repo/index.html',
       isDirectory: false,
       size: 31,
-      mimeType: 'text/html',
-      content: '',
-      lastModified: new Date(),
+      mimeType: 'text/html' as const,
+      lastModified,
     }
 
-    it('should serve HTML files with sandbox CSP headers', async () => {
-      getFile.mockResolvedValue(htmlFileInfo)
+    it('should serve HTML files with sandbox CSP and caching headers', async () => {
+      getFilePreviewStat.mockResolvedValue(htmlStat)
       getRawFileContent.mockResolvedValue(Buffer.from('<html><body>Hello</body></html>'))
 
       const response = await app.request('/api/files/preview/test-repo/index.html')
@@ -94,23 +96,40 @@ describe('File Routes', () => {
       expect(response.headers.get('Content-Disposition')).toContain('inline')
       expect(response.headers.get('X-Content-Type-Options')).toBe('nosniff')
       expect(response.headers.get('Referrer-Policy')).toBe('no-referrer')
-      expect(response.headers.get('Content-Security-Policy')).toContain('sandbox allow-scripts')
+      expect(response.headers.get('Content-Security-Policy')).toContain('sandbox allow-scripts allow-same-origin')
       expect(response.headers.get('Content-Security-Policy')).toContain('https:')
-      expect(getFile).toHaveBeenCalledWith('test-repo/index.html')
+      expect(response.headers.get('Cache-Control')).toBe('private, must-revalidate, max-age=0')
+      expect(response.headers.get('ETag')).toBeTruthy()
+      expect(response.headers.get('Last-Modified')).toBe(lastModified.toUTCString())
+      expect(getFilePreviewStat).toHaveBeenCalledWith('test-repo/index.html')
       expect(getRawFileContent).toHaveBeenCalledWith('test-repo/index.html')
     })
 
+    it('should return 304 when ETag matches If-None-Match without reading the file', async () => {
+      getFilePreviewStat.mockResolvedValue(htmlStat)
+      getRawFileContent.mockResolvedValue(Buffer.from('<html><body>Hello</body></html>'))
+
+      const first = await app.request('/api/files/preview/test-repo/index.html')
+      const etag = first.headers.get('ETag') as string
+      await first.text()
+      getRawFileContent.mockClear()
+
+      const response = await app.request('/api/files/preview/test-repo/index.html', {
+        headers: { 'If-None-Match': etag },
+      })
+
+      expect(response.status).toBe(304)
+      expect(getRawFileContent).not.toHaveBeenCalled()
+    })
+
     it('should serve CSS files with text/css Content-Type', async () => {
-      const cssFileInfo: FileInfo = {
+      getFilePreviewStat.mockResolvedValue({
         name: 'styles.css',
-        path: 'test-repo/styles/app.css',
         isDirectory: false,
         size: 50,
         mimeType: 'text/css',
-        content: '',
-        lastModified: new Date(),
-      }
-      getFile.mockResolvedValue(cssFileInfo)
+        lastModified,
+      })
       getRawFileContent.mockResolvedValue(Buffer.from('body { color: red }'))
 
       const response = await app.request('/api/files/preview/test-repo/styles/app.css')
@@ -118,11 +137,11 @@ describe('File Routes', () => {
       expect(response.status).toBe(200)
       expect(response.headers.get('Content-Type')).toContain('text/css')
       expect(response.headers.get('Content-Security-Policy')).toBeNull()
-      expect(getFile).toHaveBeenCalledWith('test-repo/styles/app.css')
+      expect(getFilePreviewStat).toHaveBeenCalledWith('test-repo/styles/app.css')
     })
 
     it('should support query-based path parameter', async () => {
-      getFile.mockResolvedValue(htmlFileInfo)
+      getFilePreviewStat.mockResolvedValue(htmlStat)
       getRawFileContent.mockResolvedValue(Buffer.from('<html><body>Hello</body></html>'))
 
       const response = await app.request('/api/files/preview?path=test-repo/index.html')
@@ -130,18 +149,17 @@ describe('File Routes', () => {
 
       expect(response.status).toBe(200)
       expect(body).toBe('<html><body>Hello</body></html>')
-      expect(getFile).toHaveBeenCalledWith('test-repo/index.html')
+      expect(getFilePreviewStat).toHaveBeenCalledWith('test-repo/index.html')
     })
 
     it('should return 400 for directory results', async () => {
-      const dirInfo: FileInfo = {
+      getFilePreviewStat.mockResolvedValue({
         name: 'test-repo',
-        path: 'test-repo',
         isDirectory: true,
         size: 0,
-        lastModified: new Date(),
-      }
-      getFile.mockResolvedValue(dirInfo)
+        mimeType: 'text/plain',
+        lastModified,
+      })
 
       const response = await app.request('/api/files/preview/test-repo')
 
@@ -151,22 +169,20 @@ describe('File Routes', () => {
     })
 
     it('should return 415 for non-previewable MIME types', async () => {
-      const pdfFileInfo: FileInfo = {
+      getFilePreviewStat.mockResolvedValue({
         name: 'doc.pdf',
-        path: 'test-repo/doc.pdf',
         isDirectory: false,
         size: 100,
-        mimeType: 'application/pdf',
-        content: '',
-        lastModified: new Date(),
-      }
-      getFile.mockResolvedValue(pdfFileInfo)
+        mimeType: 'application/pdf' as never,
+        lastModified,
+      })
 
       const response = await app.request('/api/files/preview/test-repo/doc.pdf')
 
       expect(response.status).toBe(415)
       const body = await response.json() as { error: string }
       expect(body.error).toContain('File type cannot be previewed')
+      expect(getRawFileContent).not.toHaveBeenCalled()
     })
 
     it('should return 400 when no path is provided', async () => {
@@ -179,7 +195,7 @@ describe('File Routes', () => {
 
     it('should return 403 for path traversal attempts', async () => {
       const error = { message: 'Path traversal detected', statusCode: 403 }
-      getFile.mockRejectedValue(error)
+      getFilePreviewStat.mockRejectedValue(error)
 
       const response = await app.request('/api/files/preview/test-repo/../outside')
 

--- a/backend/test/routes/internal/git-credentials.test.ts
+++ b/backend/test/routes/internal/git-credentials.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Database } from 'bun:sqlite'
+import { migrate } from '../../../src/db/migration-runner'
+import { allMigrations } from '../../../src/db/migrations'
+import { SettingsService } from '../../../src/services/settings'
+import { createInternalGitCredentialsRoutes } from '../../../src/routes/internal/git-credentials'
+import type { GitCredential } from '@opencode-manager/shared'
+
+describe('internal git-credentials routes', () => {
+  let db: Database
+  let settingsService: SettingsService
+  let app: ReturnType<typeof createInternalGitCredentialsRoutes>
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    migrate(db, allMigrations)
+    settingsService = new SettingsService(db)
+    app = createInternalGitCredentialsRoutes(db)
+  })
+
+  it('GET /gh-env returns GH_TOKEN and GITHUB_TOKEN for a GitHub PAT', async () => {
+    settingsService.updateSettings({
+      gitCredentials: [
+        { name: 'github', host: 'github.com', type: 'pat', token: 'ghp_test_token' } as GitCredential,
+      ],
+    })
+
+    const res = await app.request('/gh-env')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({ GH_TOKEN: 'ghp_test_token', GITHUB_TOKEN: 'ghp_test_token' })
+  })
+
+  it('GET /gh-env returns an empty object when no GitHub credential exists', async () => {
+    const res = await app.request('/gh-env')
+
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({})
+  })
+})

--- a/backend/test/services/credential-provider.test.ts
+++ b/backend/test/services/credential-provider.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { Database } from 'bun:sqlite'
+import { migrate } from '../../src/db/migration-runner'
+import { allMigrations } from '../../src/db/migrations'
+import { SettingsService } from '../../src/services/settings'
+import { CredentialProvider } from '../../src/services/credential-provider'
+import { createRepo, setRepoGitCredentialId } from '../../src/db/queries'
+import type { GitCredential } from '@opencode-manager/shared'
+
+function createPatCredential(name: string, host: string, token: string, username?: string, id?: string): GitCredential {
+  return {
+    ...(id ? { id } : {}),
+    name,
+    host,
+    token,
+    ...(username ? { username } : {}),
+  } as GitCredential
+}
+
+function createSshCredential(name: string, host: string, sshPrivateKeyEncrypted?: string): GitCredential {
+  return {
+    name,
+    host,
+    type: 'ssh',
+    ...(sshPrivateKeyEncrypted ? { sshPrivateKeyEncrypted } : {}),
+  } as GitCredential
+}
+
+describe('CredentialProvider', () => {
+  let db: Database
+  let settingsService: SettingsService
+  let provider: CredentialProvider
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    migrate(db, allMigrations)
+    settingsService = new SettingsService(db)
+    provider = new CredentialProvider(db)
+  })
+
+  describe('with seeded credentials', () => {
+    const githubPat: GitCredential = createPatCredential('github-pat', 'github.com', 'ghp_test_token')
+    const gitlabPat: GitCredential = createPatCredential('gitlab-pat', 'gitlab.com', 'glpat_test_token', 'custom-user')
+    const githubSsh: GitCredential = createSshCredential('github-ssh', 'github.com')
+
+    beforeEach(() => {
+      settingsService.updateSettings({ gitCredentials: [githubPat, gitlabPat, githubSsh] })
+    })
+
+    it('getPatCredentialForHost returns the matching PAT credential', () => {
+      const result = provider.getPatCredentialForHost('github.com')
+      expect(result).toEqual({ username: 'x-access-token', password: 'ghp_test_token' })
+    })
+
+    it('getPatCredentialForHost uses custom username when provided', () => {
+      const result = provider.getPatCredentialForHost('gitlab.com')
+      expect(result).toEqual({ username: 'custom-user', password: 'glpat_test_token' })
+    })
+
+    it('getPatCredentialForHost returns null for unmatched host', () => {
+      expect(provider.getPatCredentialForHost('bitbucket.org')).toBeNull()
+    })
+
+    it('getPatCredentialForHost prefers the configured default PAT for the host', () => {
+      const first = createPatCredential('first', 'github.com', 'first-token', undefined, 'first-id')
+      const second = createPatCredential('second', 'github.com', 'second-token', undefined, 'second-id')
+      settingsService.updateSettings({ gitCredentials: [first, second], defaultGitCredentialId: 'second-id' })
+
+      expect(provider.getPatCredentialForHost('github.com')).toEqual({ username: 'x-access-token', password: 'second-token' })
+    })
+
+    it('getPatCredentialForHost prefers repo-specific PAT for the cwd', () => {
+      const first = createPatCredential('first', 'github.com', 'first-token', undefined, 'first-id')
+      const second = createPatCredential('second', 'github.com', 'second-token', undefined, 'second-id')
+      settingsService.updateSettings({ gitCredentials: [first, second], defaultGitCredentialId: 'first-id' })
+      const repo = createRepo(db, {
+        repoUrl: 'https://github.com/acme/repo.git',
+        localPath: 'repo',
+        defaultBranch: 'main',
+        cloneStatus: 'ready',
+        clonedAt: Date.now(),
+      })
+      setRepoGitCredentialId(db, repo.id, 'second-id')
+
+      expect(provider.getPatCredentialForHost('github.com', { cwd: repo.fullPath })).toEqual({ username: 'x-access-token', password: 'second-token' })
+    })
+
+    it('getPatCredentialForHost ignores selected credentials for other hosts', () => {
+      const github = createPatCredential('github', 'github.com', 'github-token', undefined, 'github-id')
+      const gitlab = createPatCredential('gitlab', 'gitlab.com', 'gitlab-token', 'custom-user', 'gitlab-id')
+      settingsService.updateSettings({ gitCredentials: [github, gitlab], defaultGitCredentialId: 'github-id' })
+
+      expect(provider.getPatCredentialForHost('gitlab.com')).toEqual({ username: 'custom-user', password: 'gitlab-token' })
+    })
+
+    it('getGhCliEnv returns GH_TOKEN and GITHUB_TOKEN for GitHub PAT', () => {
+      const env = provider.getGhCliEnv()
+      expect(env).toEqual({ GH_TOKEN: 'ghp_test_token', GITHUB_TOKEN: 'ghp_test_token' })
+    })
+
+    it('getGhCliEnv prefers the configured default GitHub PAT', () => {
+      const first = createPatCredential('first', 'github.com', 'first-token', undefined, 'first-id')
+      const second = createPatCredential('second', 'github.com', 'second-token', undefined, 'second-id')
+      settingsService.updateSettings({ gitCredentials: [first, second], defaultGitCredentialId: 'second-id' })
+
+      expect(provider.getGhCliEnv()).toEqual({ GH_TOKEN: 'second-token', GITHUB_TOKEN: 'second-token' })
+    })
+
+    it('getGhCliEnv prefers repo-specific GitHub PAT for the cwd', () => {
+      const first = createPatCredential('first', 'github.com', 'first-token', undefined, 'first-id')
+      const second = createPatCredential('second', 'github.com', 'second-token', undefined, 'second-id')
+      settingsService.updateSettings({ gitCredentials: [first, second], defaultGitCredentialId: 'first-id' })
+      const repo = createRepo(db, {
+        repoUrl: 'https://github.com/acme/repo.git',
+        localPath: 'repo',
+        defaultBranch: 'main',
+        cloneStatus: 'ready',
+        clonedAt: Date.now(),
+      })
+      setRepoGitCredentialId(db, repo.id, 'second-id')
+
+      expect(provider.getGhCliEnv({ cwd: repo.fullPath })).toEqual({ GH_TOKEN: 'second-token', GITHUB_TOKEN: 'second-token' })
+    })
+
+    it('getGitEnv returns git config env for configured PATs', () => {
+      const env = provider.getGitEnv()
+      expect(env.GIT_TERMINAL_PROMPT).toBe('0')
+      expect(env.GIT_CONFIG_COUNT).toBe('2')
+    })
+
+    it('getSshCredentialsForHost returns SSH credentials and excludes PATs', () => {
+      const sshCreds = provider.getSshCredentialsForHost('github.com')
+      expect(sshCreds).toHaveLength(1)
+      expect(sshCreds[0]).toMatchObject({ name: 'github-ssh', type: 'ssh' })
+    })
+
+    it('getSshCredentialsForHost returns empty array for unmatched host', () => {
+      expect(provider.getSshCredentialsForHost('gitlab.com')).toEqual([])
+    })
+
+    it('getSshCredentialsWithPrivateKey returns only encrypted SSH credentials', () => {
+      const encryptedSsh = createSshCredential('encrypted-ssh', 'example.com', 'encrypted-key')
+      settingsService.updateSettings({ gitCredentials: [githubPat, githubSsh, encryptedSsh] })
+      expect(provider.getSshCredentialsWithPrivateKey()).toEqual([encryptedSsh])
+    })
+  })
+
+  describe('with no credentials', () => {
+    it('getPatCredentialForHost returns null', () => {
+      expect(provider.getPatCredentialForHost('github.com')).toBeNull()
+    })
+
+    it('getGhCliEnv returns empty object', () => {
+      expect(provider.getGhCliEnv()).toEqual({})
+    })
+
+    it('getGitEnv returns disabled terminal prompt defaults', () => {
+      expect(provider.getGitEnv()).toEqual({ GIT_TERMINAL_PROMPT: '0', GIT_CONFIG_COUNT: '0' })
+    })
+
+    it('getSshCredentialsForHost returns empty array', () => {
+      expect(provider.getSshCredentialsForHost('github.com')).toEqual([])
+    })
+
+    it('getSshCredentialsWithPrivateKey returns empty array', () => {
+      expect(provider.getSshCredentialsWithPrivateKey()).toEqual([])
+    })
+  })
+
+  describe('getGitCredentials', () => {
+    it('returns empty array when no credentials are stored', () => {
+      expect(provider.getGitCredentials()).toEqual([])
+    })
+
+    it('returns all stored credentials', () => {
+      const creds = [createPatCredential('test', 'example.com', 'tok'), createSshCredential('ssh-test', 'example.com')]
+      settingsService.updateSettings({ gitCredentials: creds })
+      expect(provider.getGitCredentials()).toHaveLength(2)
+    })
+  })
+})

--- a/backend/test/services/git-auth.test.ts
+++ b/backend/test/services/git-auth.test.ts
@@ -89,7 +89,7 @@ vi.mock('../ipc/ipcServer', () => ({
   IPCServer: vi.fn(),
 }))
 
-vi.mock('../ipc/askpassHandler', () => ({
+vi.mock('../../src/ipc/askpassHandler', () => ({
   AskpassHandler: vi.fn().mockImplementation(() => ({
     getEnv: vi.fn().mockReturnValue({}),
   })),
@@ -100,6 +100,15 @@ vi.mock('../../src/ipc/sshHostKeyHandler', () => ({
     initialize: vi.fn().mockResolvedValue(undefined),
     getKnownHostsPath: vi.fn().mockReturnValue(null),
     getEnv: vi.fn().mockReturnValue({}),
+  })),
+}))
+
+vi.mock('../../src/services/credential-provider', () => ({
+  CredentialProvider: vi.fn().mockImplementation(() => ({
+    getGhCliEnv: vi.fn().mockReturnValue({}),
+    getSshCredentialsForHost: vi.fn().mockReturnValue([]),
+    getPatCredentialForHost: vi.fn().mockReturnValue(null),
+    getGitCredentials: vi.fn().mockReturnValue([]),
   })),
 }))
 

--- a/backend/test/services/git/GitService.test.ts
+++ b/backend/test/services/git/GitService.test.ts
@@ -49,6 +49,7 @@ describe('GitService', () => {
   let database: Database
   let mockGitAuthService: GitAuthService
   let mockSettingsService: any
+  let mockCredentialProvider: any
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -70,7 +71,10 @@ describe('GitService', () => {
         },
       }),
     }
-    service = new GitService(mockGitAuthService, mockSettingsService)
+    mockCredentialProvider = {
+      getGitCredentials: vi.fn().mockReturnValue([]),
+    }
+    service = new GitService(mockGitAuthService, mockSettingsService, mockCredentialProvider)
   })
 
   describe('getStatus', () => {
@@ -639,7 +643,7 @@ describe('GitService', () => {
       expect(getRepoById).toHaveBeenCalledWith(database, 1)
       expect(executeCommand).toHaveBeenCalledWith(
         ['git', '-C', '/path/to/repo', 'push'],
-        { env: expect.any(Object) }
+        { env: expect.objectContaining({ OCM_GIT_REPO_ID: '1', OCM_GIT_REPO_CWD: '/path/to/repo' }) }
       )
       expect(result).toBe('Everything up-to-date')
     })
@@ -681,6 +685,10 @@ describe('GitService', () => {
 
       const result = await service.fetch(1, database)
 
+      expect(executeCommand).toHaveBeenCalledWith(
+        ['git', '-C', '/path/to/repo', 'fetch', '--all', '--prune'],
+        { env: expect.objectContaining({ OCM_GIT_REPO_ID: '1', OCM_GIT_REPO_CWD: '/path/to/repo' }) }
+      )
       expect(result).toBe('')
     })
   })
@@ -700,6 +708,10 @@ describe('GitService', () => {
 
       const result = await service.pull(1, database)
 
+      expect(executeCommand).toHaveBeenCalledWith(
+        ['git', '-C', '/path/to/repo', 'pull'],
+        { env: expect.objectContaining({ OCM_GIT_REPO_ID: '1', OCM_GIT_REPO_CWD: '/path/to/repo' }) }
+      )
       expect(result).toBe('')
     })
   })

--- a/backend/test/services/opencode-gh-env-plugin.test.ts
+++ b/backend/test/services/opencode-gh-env-plugin.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { promises as fs } from 'fs'
+import path from 'path'
+import os from 'os'
+import { pathToFileURL } from 'url'
+import { installGhEnvPlugin, getGhEnvPluginDir } from '../../src/services/opencode-gh-env-plugin'
+
+type ShellEnvHook = (
+  input: { cwd: string },
+  output: { env: Record<string, string> },
+) => Promise<void>
+type PluginFactory = () => Promise<{ 'shell.env': ShellEnvHook }>
+
+async function loadPlugin(configHome: string): Promise<PluginFactory> {
+  const file = path.join(getGhEnvPluginDir(configHome), 'ocm-gh-env.js')
+  const mod = await import(pathToFileURL(file).href)
+  return mod.default as PluginFactory
+}
+
+describe('ocm-gh-env plugin', () => {
+  let configHome: string
+
+  beforeEach(async () => {
+    configHome = await fs.mkdtemp(path.join(os.tmpdir(), 'ocm-ghenv-'))
+    await installGhEnvPlugin(configHome)
+    process.env.OCM_INTERNAL_API_URL = 'http://localhost:5003/api/internal'
+    process.env.OCM_INTERNAL_TOKEN = 'secret-token'
+  })
+
+  afterEach(async () => {
+    vi.unstubAllGlobals()
+    delete process.env.OCM_INTERNAL_API_URL
+    delete process.env.OCM_INTERNAL_TOKEN
+    await fs.rm(configHome, { recursive: true, force: true })
+  })
+
+  it('writes the plugin file into the auto-discovery dir', async () => {
+    const file = path.join(getGhEnvPluginDir(configHome), 'ocm-gh-env.js')
+    await expect(fs.access(file)).resolves.toBeUndefined()
+  })
+
+  it('injects fetched GH env into output.env', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ GH_TOKEN: 'ghp', GITHUB_TOKEN: 'ghp' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const factory = await loadPlugin(configHome)
+    const hooks = await factory()
+    const output = { env: {} as Record<string, string> }
+    await hooks['shell.env']({ cwd: '/repo' }, output)
+
+    expect(output.env).toEqual({ GH_TOKEN: 'ghp', GITHUB_TOKEN: 'ghp' })
+    const [url, options] = fetchMock.mock.calls[0]!
+    expect(url.toString()).toBe('http://localhost:5003/api/internal/git-credentials/gh-env?cwd=%2Frepo')
+    expect(options).toEqual({ headers: { Authorization: 'Bearer secret-token' } })
+  })
+
+  it('does not fetch when the internal env vars are missing', async () => {
+    delete process.env.OCM_INTERNAL_API_URL
+    delete process.env.OCM_INTERNAL_TOKEN
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const factory = await loadPlugin(configHome)
+    const hooks = await factory()
+    const output = { env: {} as Record<string, string> }
+    await hooks['shell.env']({ cwd: '/repo' }, output)
+
+    expect(output.env).toEqual({})
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('never throws when the fetch fails', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('network down'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const factory = await loadPlugin(configHome)
+    const hooks = await factory()
+    const output = { env: {} as Record<string, string> }
+
+    await expect(hooks['shell.env']({ cwd: '/repo' }, output)).resolves.toBeUndefined()
+    expect(output.env).toEqual({})
+  })
+
+  it('caches results within the TTL so rapid calls fetch once', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ GH_TOKEN: 'ghp', GITHUB_TOKEN: 'ghp' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const factory = await loadPlugin(configHome)
+    const hooks = await factory()
+    const out1 = { env: {} as Record<string, string> }
+    const out2 = { env: {} as Record<string, string> }
+    await hooks['shell.env']({ cwd: '/repo' }, out1)
+    await hooks['shell.env']({ cwd: '/repo' }, out2)
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(out2.env).toEqual({ GH_TOKEN: 'ghp', GITHUB_TOKEN: 'ghp' })
+  })
+
+  it('caches results per cwd', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ GH_TOKEN: 'ghp', GITHUB_TOKEN: 'ghp' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const factory = await loadPlugin(configHome)
+    const hooks = await factory()
+    await hooks['shell.env']({ cwd: '/repo-a' }, { env: {} })
+    await hooks['shell.env']({ cwd: '/repo-b' }, { env: {} })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/backend/test/services/opencode-single-server.test.ts
+++ b/backend/test/services/opencode-single-server.test.ts
@@ -179,7 +179,7 @@ describe('OpenCodeServerManager - server auth', () => {
   function createPasswordDb(password: string | null) {
     const encrypted = password ? encryptSecret(password) : null
 
-    return {
+    const db = {
       prepare: vi.fn((sql: string) => ({
         get: (key?: string) => {
           if (key === 'opencode_server_password' && sql.includes('SELECT value FROM app_secrets') && encrypted) {
@@ -190,7 +190,10 @@ describe('OpenCodeServerManager - server auth', () => {
         run: vi.fn(),
         all: vi.fn(() => []),
       })),
-    } as any
+      query: vi.fn((sql: string) => db.prepare(sql)),
+    }
+
+    return db as any
   }
 })
 

--- a/backend/test/utils/git-auth.test.ts
+++ b/backend/test/utils/git-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchGitHubUserInfo, findGitHubCredential, resolveGitIdentity, createGitIdentityEnv, getSSHCredentialsForHost, createGitEnv, getDefaultUsername, normalizeHost } from '../../src/utils/git-auth'
+import { fetchGitHubUserInfo, findGitHubCredential, findPatCredentialForHost, resolveGitIdentity, createGitIdentityEnv, getSSHCredentialsForHost, createGitEnv, createGhCliEnv, getDefaultUsername, normalizeHost } from '../../src/utils/git-auth'
 import type { GitCredential } from '@opencode-manager/shared'
 
 describe('fetchGitHubUserInfo', () => {
@@ -239,6 +239,48 @@ describe('createGitEnv', () => {
   })
 })
 
+describe('createGhCliEnv', () => {
+  it('returns GH_TOKEN and GITHUB_TOKEN set to the token for a github PAT', () => {
+    const credentials: GitCredential[] = [
+      { name: 'github', host: 'https://github.com/', type: 'pat', token: 'gh-cli-token' },
+    ]
+
+    const env = createGhCliEnv(credentials)
+
+    expect(env).toEqual({ GH_TOKEN: 'gh-cli-token', GITHUB_TOKEN: 'gh-cli-token' })
+  })
+
+  it('returns {} when no github credential exists', () => {
+    const credentials: GitCredential[] = [
+      { name: 'gitlab', host: 'https://gitlab.com/', type: 'pat', token: 'gl-token' },
+    ]
+
+    const env = createGhCliEnv(credentials)
+
+    expect(env).toEqual({})
+  })
+
+  it('returns {} when github credential has an empty token', () => {
+    const credentials: GitCredential[] = [
+      { name: 'github', host: 'https://github.com/', type: 'pat', token: '' },
+    ]
+
+    const env = createGhCliEnv(credentials)
+
+    expect(env).toEqual({})
+  })
+
+  it('returns {} when only an ssh github credential exists', () => {
+    const credentials: GitCredential[] = [
+      { name: 'github-ssh', host: 'git@github.com', type: 'ssh', sshPrivateKey: 'key' },
+    ]
+
+    const env = createGhCliEnv(credentials)
+
+    expect(env).toEqual({})
+  })
+})
+
 describe('normalizeHost', () => {
   it('returns a URL-form host prefix for git url matching', () => {
     expect(normalizeHost('github.com')).toBe('https://github.com/')
@@ -322,6 +364,79 @@ describe('findGitHubCredential', () => {
     ]
 
     expect(findGitHubCredential(credentials)).toEqual(credentials[1])
+  })
+})
+
+describe('findPatCredentialForHost', () => {
+  it('matches by hostname when stored as full https URL', () => {
+    const credentials: GitCredential[] = [
+      { name: 'github', host: 'https://github.com/owner/repo.git', type: 'pat', token: 'gh-token' },
+    ]
+
+    const result = findPatCredentialForHost(credentials, 'github.com')
+
+    expect(result).toEqual({ username: 'x-access-token', password: 'gh-token' })
+  })
+
+  it('uses explicit username when provided', () => {
+    const credentials: GitCredential[] = [
+      { name: 'github', host: 'github.com', type: 'pat', token: 'gh-token', username: 'custom-user' },
+    ]
+
+    const result = findPatCredentialForHost(credentials, 'github.com')
+
+    expect(result).toEqual({ username: 'custom-user', password: 'gh-token' })
+  })
+
+  it('returns x-access-token default for github hosts', () => {
+    const credentials: GitCredential[] = [
+      { name: 'github', host: 'github.com', type: 'pat', token: 'gh-token' },
+    ]
+
+    const result = findPatCredentialForHost(credentials, 'github.com')
+
+    expect(result?.username).toBe('x-access-token')
+  })
+
+  it('returns oauth2 default for non-github hosts', () => {
+    const credentials: GitCredential[] = [
+      { name: 'gitlab', host: 'gitlab.com', type: 'pat', token: 'gl-token' },
+    ]
+
+    const result = findPatCredentialForHost(credentials, 'gitlab.com')
+
+    expect(result?.username).toBe('oauth2')
+  })
+
+  it('ignores ssh credentials', () => {
+    const credentials: GitCredential[] = [
+      { name: 'github-ssh', host: 'github.com', type: 'ssh', sshPrivateKey: 'key' },
+      { name: 'github-pat', host: 'github.com', type: 'pat', token: 'pat-token' },
+    ]
+
+    const result = findPatCredentialForHost(credentials, 'github.com')
+
+    expect(result).toEqual({ username: 'x-access-token', password: 'pat-token' })
+  })
+
+  it('returns null when no credential matches the host', () => {
+    const credentials: GitCredential[] = [
+      { name: 'gitlab', host: 'gitlab.com', type: 'pat', token: 'gl-token' },
+    ]
+
+    const result = findPatCredentialForHost(credentials, 'github.com')
+
+    expect(result).toBeNull()
+  })
+
+  it('returns empty password when matched credential has no token', () => {
+    const credentials: GitCredential[] = [
+      { name: 'github', host: 'github.com', type: 'pat' },
+    ]
+
+    const result = findPatCredentialForHost(credentials, 'github.com')
+
+    expect(result).toEqual({ username: 'x-access-token', password: '' })
   })
 })
 

--- a/frontend/src/api/files.test.ts
+++ b/frontend/src/api/files.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { getFileApiUrl } from './files'
+import { encodePathForRoute, getFilePreviewUrl } from './files'
+
+describe('getFilePreviewUrl', () => {
+  it('constructs preview URL with encoded path segments', () => {
+    const url = getFilePreviewUrl('repo/dir/index.html')
+    expect(url).toBe('/api/files/preview/repo/dir/index.html')
+  })
+
+  it('encodes spaces per segment', () => {
+    const url = getFilePreviewUrl('my repo/file name.html')
+    expect(url).toBe('/api/files/preview/my%20repo/file%20name.html')
+  })
+
+  it('encodes hash characters per segment', () => {
+    const url = getFilePreviewUrl('repo/file#1.html')
+    expect(url).toBe('/api/files/preview/repo/file%231.html')
+  })
+})
+
+describe('encodePathForRoute', () => {
+  it('encodes each path segment separately', () => {
+    const result = encodePathForRoute('repo/dir/index.html')
+    expect(result).toBe('repo/dir/index.html')
+  })
+
+  it('encodes special characters per segment', () => {
+    const result = encodePathForRoute('my dir/file name.html')
+    expect(result).toBe('my%20dir/file%20name.html')
+  })
+})
+
+describe('getFileApiUrl - existing behavior unchanged', () => {
+  it('still returns a URL with path query param', () => {
+    const url = getFileApiUrl('repo/dir/index.html')
+    expect(url).toContain('/api/files')
+    expect(url).toContain('path=repo%2Fdir%2Findex.html')
+  })
+})

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -77,3 +77,12 @@ export async function applyFilePatches(path: string, patches: PatchOperation[]):
     body: JSON.stringify({ patches }),
   })
 }
+
+export function encodePathForRoute(path: string): string {
+  return path.split('/').map(encodeURIComponent).join('/')
+}
+
+export function getFilePreviewUrl(path: string): string {
+  const encodedPath = encodePathForRoute(path)
+  return `${API_BASE_URL}/api/files/preview/${encodedPath}`
+}

--- a/frontend/src/api/repos.ts
+++ b/frontend/src/api/repos.ts
@@ -114,6 +114,14 @@ export async function switchRepoConfig(id: number, configName: string): Promise<
   })
 }
 
+export async function updateRepoGitCredential(id: number, credentialId?: string): Promise<Repo> {
+  return fetchWrapper(`${API_BASE_URL}/api/repos/${id}/git-credential`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ credentialId }),
+  })
+}
+
 export class GitAuthError extends Error {
   code: string
   constructor(message: string, code: string) {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -12,6 +12,7 @@ export interface Repo {
   lastPulled?: number
   lastAccessedAt?: number
   openCodeConfigName?: string
+  gitCredentialId?: string
   isWorktree?: boolean
   isLocal?: boolean
 }

--- a/frontend/src/api/types/settings.ts
+++ b/frontend/src/api/types/settings.ts
@@ -30,6 +30,7 @@ export interface CustomCommand {
 }
 
 export interface GitCredential {
+  id?: string
   name: string
   host: string
   type: 'pat' | 'ssh'
@@ -61,6 +62,7 @@ export interface UserPreferences {
   keyboardShortcuts: Record<string, string>
   customCommands: CustomCommand[]
   gitCredentials?: GitCredential[]
+  defaultGitCredentialId?: string
   gitIdentity?: GitIdentity
   tts?: TTSConfig
   stt?: STTConfig

--- a/frontend/src/components/file-browser/FileBrowser.tsx
+++ b/frontend/src/components/file-browser/FileBrowser.tsx
@@ -12,6 +12,9 @@ import { FolderOpen, Upload, RefreshCw, X } from 'lucide-react'
 import type { FileInfo } from '@/types/files'
 import { useMobile } from '@/hooks/useMobile'
 import { getFileApiUrl, useFile } from '@/api/files'
+import { HtmlArtifactPanel } from '@/components/html-preview/HtmlArtifactPanel'
+import type { HtmlArtifact } from '@/lib/htmlArtifacts'
+import { createHtmlArtifact, isHtmlPath } from '@/lib/htmlArtifacts'
 
 export interface FileBrowserHandle {
   goBack: () => void
@@ -50,6 +53,10 @@ const encodeBase64 = (content: string) => {
   }
   return btoa(binary)
 }
+
+const isHtmlFileInfo = (file: FileInfo): boolean => (
+  isHtmlPath(file.path) || isHtmlPath(file.name) || file.mimeType === 'text/html'
+)
 
 async function readFileEntry(entry: FileSystemFileEntry): Promise<File> {
   return new Promise((resolve, reject) => {
@@ -135,6 +142,7 @@ export const FileBrowser = forwardRef<FileBrowserHandle, FileBrowserProps>(funct
   const [currentPath, setCurrentPath] = useState(basePath)
   const [files, setFiles] = useState<FileInfo | null>(null)
   const [selectedFile, setSelectedFile] = useState<FileInfo | null>(null)
+  const [htmlArtifact, setHtmlArtifact] = useState<HtmlArtifact | null>(null)
   const [searchQuery, setSearchQuery] = useState('')
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -152,7 +160,17 @@ useEffect(() => {
   if (initialFileData) {
     setSelectedFile(initialFileData)
     if (isMobile) {
-      setIsPreviewModalOpen(true)
+      if (isHtmlFileInfo(initialFileData)) {
+        setHtmlArtifact(createHtmlArtifact({
+          source: 'file',
+          path: initialFileData.path,
+          title: initialFileData.name,
+        }))
+        setIsPreviewModalOpen(false)
+      } else {
+        setHtmlArtifact(null)
+        setIsPreviewModalOpen(true)
+      }
       onPreviewStateChange?.(true)
     }
   }
@@ -262,7 +280,17 @@ useEffect(() => {
       
       // On mobile, open preview in modal
       if (isMobile) {
-        setIsPreviewModalOpen(true)
+        if (isHtmlFileInfo(fullFileData)) {
+          setHtmlArtifact(createHtmlArtifact({
+            source: 'file',
+            path: fullFileData.path,
+            title: fullFileData.name,
+          }))
+          setIsPreviewModalOpen(false)
+        } else {
+          setHtmlArtifact(null)
+          setIsPreviewModalOpen(true)
+        }
         onPreviewStateChange?.(true)
       }
     } catch (err) {
@@ -275,9 +303,18 @@ useEffect(() => {
 
   const handleCloseModal = useCallback(() => {
     setIsPreviewModalOpen(false)
+    setHtmlArtifact(null)
     setSelectedFile(null)
     onPreviewStateChange?.(false)
   }, [onPreviewStateChange])
+
+  const handleCloseHtmlArtifact = useCallback(() => {
+    setHtmlArtifact(null)
+    setSelectedFile(null)
+    onPreviewStateChange?.(false)
+  }, [onPreviewStateChange])
+
+  const handleToggleHtmlArtifactFullscreen = useCallback(() => {}, [])
 
   const handleDirectoryClick = (path: string) => {
     loadFiles(path)
@@ -645,6 +682,16 @@ useEffect(() => {
           file={selectedFile}
           showFilePreviewHeader={true}
         />
+
+        {isMobile && htmlArtifact && (
+          <HtmlArtifactPanel
+            artifact={htmlArtifact}
+            isFullscreen={true}
+            isMobile={true}
+            onClose={handleCloseHtmlArtifact}
+            onToggleFullscreen={handleToggleHtmlArtifactFullscreen}
+          />
+        )}
       </div>
     )
   }
@@ -746,6 +793,16 @@ useEffect(() => {
         onClose={handleCloseModal}
         file={selectedFile}
       />
+
+      {isMobile && htmlArtifact && (
+        <HtmlArtifactPanel
+          artifact={htmlArtifact}
+          isFullscreen={true}
+          isMobile={true}
+          onClose={handleCloseHtmlArtifact}
+          onToggleFullscreen={handleToggleHtmlArtifactFullscreen}
+        />
+      )}
       
       {uploadDialog}
     </div>

--- a/frontend/src/components/file-browser/FileBrowserSheet.test.tsx
+++ b/frontend/src/components/file-browser/FileBrowserSheet.test.tsx
@@ -7,6 +7,15 @@ import { FileBrowser } from './FileBrowser'
 import type { FileBrowserHandle } from './FileBrowser'
 import * as useMobile from '../../hooks/useMobile'
 
+vi.mock('@/components/html-preview/HtmlArtifactPanel', () => ({
+  HtmlArtifactPanel: ({ artifact, onClose }: { artifact: { path?: string } | null; onClose: () => void }) => (
+    <div data-testid="html-artifact-panel">
+      <span>{artifact?.path}</span>
+      <button aria-label="Close preview" onClick={onClose}>Close</button>
+    </div>
+  ),
+}))
+
 function createQueryClient() {
   return new QueryClient({
     defaultOptions: {
@@ -87,6 +96,60 @@ describe('FileBrowserSheet', () => {
 })
 
 describe('FileBrowser navigation', () => {
+  it('opens mobile HTML files with the shared HTML artifact panel', async () => {
+    const mobileSpy = vi.spyOn(useMobile, 'useMobile').mockReturnValue(true)
+    const originalFetch = globalThis.fetch
+    const htmlFile = {
+      name: 'dashboard.html',
+      path: 'test-repo/dashboard.html',
+      isDirectory: false,
+      size: 24,
+      mimeType: 'text/html',
+      content: btoa('<h1>Dashboard</h1>'),
+      lastModified: new Date(),
+    }
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = new URL(String(input), 'http://localhost')
+      const path = url.searchParams.get('path')
+
+      if (path === htmlFile.path) {
+        return {
+          ok: true,
+          json: async () => htmlFile,
+        } as Response
+      }
+
+      return {
+        ok: true,
+        json: async () => ({
+          name: 'test-repo',
+          path: 'test-repo',
+          isDirectory: true,
+          children: [htmlFile],
+        }),
+      } as Response
+    })
+
+    try {
+      render(
+        <FileBrowser
+          basePath="test-repo"
+          embedded={true}
+        />,
+        { wrapper: createWrapper() }
+      )
+
+      fireEvent.click(await screen.findByText('dashboard.html'))
+
+      expect(await screen.findByTestId('html-artifact-panel')).toHaveTextContent('test-repo/dashboard.html')
+      expect(screen.queryByTitle('HTML preview: dashboard.html')).not.toBeInTheDocument()
+    } finally {
+      globalThis.fetch = originalFetch
+      mobileSpy.mockRestore()
+    }
+  })
+
   it('exposes imperative handle with goBack, canGoBack, and getCurrentPath', () => {
     const ref = { current: null as unknown as FileBrowserHandle }
     
@@ -1091,5 +1154,3 @@ describe('FileBrowserSheet swipe decision integration', () => {
     mockUseSwipeBack.mockRestore()
   })
 })
-
-

--- a/frontend/src/components/file-browser/FilePreview.test.tsx
+++ b/frontend/src/components/file-browser/FilePreview.test.tsx
@@ -47,7 +47,7 @@ describe('FilePreview - HTML preview', () => {
 
     const iframe = screen.getByTitle('HTML preview: dashboard.html')
     expect(iframe).toBeInTheDocument()
-    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
+    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts allow-same-origin')
     expect(iframe.getAttribute('src')).toContain('/api/files/preview/test-repo/dashboard.html')
   })
 

--- a/frontend/src/components/file-browser/FilePreview.test.tsx
+++ b/frontend/src/components/file-browser/FilePreview.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { FilePreview } from './FilePreview'
+import type { FileInfo } from '@/types/files'
+
+vi.mock('@/api/files', () => ({
+  getFileApiUrl: (path: string) => `/api/files?path=${encodeURIComponent(path)}`,
+  getFilePreviewUrl: (path: string) => {
+    const encodedPath = path.split('/').map(encodeURIComponent).join('/')
+    return `/api/files/preview/${encodedPath}`
+  },
+}))
+
+vi.mock('@/components/ui/virtualized-text-view', () => ({
+  VirtualizedTextView: vi.fn(() => <div data-testid="virtualized-text-view" />),
+}))
+
+function htmlFile(content: string, overrides?: Partial<FileInfo>): FileInfo {
+  return {
+    name: 'dashboard.html',
+    path: 'test-repo/dashboard.html',
+    isDirectory: false,
+    size: content.length,
+    mimeType: 'text/html',
+    content: btoa(content),
+    lastModified: new Date(),
+    ...overrides,
+  }
+}
+
+function textFile(name: string, content: string, mimeType: string): FileInfo {
+  return {
+    name,
+    path: `test-repo/${name}`,
+    isDirectory: false,
+    size: content.length,
+    mimeType,
+    content: btoa(content),
+    lastModified: new Date(),
+  }
+}
+
+describe('FilePreview - HTML preview', () => {
+  it('renders HTML preview iframe by default for .html file', () => {
+    render(<FilePreview file={htmlFile('<h1>Dashboard</h1>')} />)
+
+    const iframe = screen.getByTitle('HTML preview: dashboard.html')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
+    expect(iframe.getAttribute('src')).toContain('/api/files/preview/test-repo/dashboard.html')
+  })
+
+  it('toggles to source view when code button is clicked', () => {
+    render(<FilePreview file={htmlFile('<h1>Dashboard</h1>')} />)
+
+    const toggleButton = screen.getByTitle('Show HTML source')
+    expect(toggleButton).toBeInTheDocument()
+
+    fireEvent.click(toggleButton)
+
+    expect(screen.queryByTitle('HTML preview: dashboard.html')).not.toBeInTheDocument()
+    expect(screen.getByText('<h1>Dashboard</h1>')).toBeInTheDocument()
+  })
+
+  it('toggles back to preview when eye button is clicked from source view', () => {
+    render(<FilePreview file={htmlFile('<h1>Dashboard</h1>')} />)
+
+    const showSourceButton = screen.getByTitle('Show HTML source')
+    fireEvent.click(showSourceButton)
+    expect(screen.queryByTitle('HTML preview: dashboard.html')).not.toBeInTheDocument()
+
+    const showPreviewButton = screen.getByTitle('Preview rendered HTML')
+    expect(showPreviewButton).toBeInTheDocument()
+
+    fireEvent.click(showPreviewButton)
+
+    const iframe = screen.getByTitle('HTML preview: dashboard.html')
+    expect(iframe).toBeInTheDocument()
+  })
+
+  it('renders HTML preview for .htm file', () => {
+    render(<FilePreview file={htmlFile('<p>HTM test</p>', { name: 'test.htm', path: 'test-repo/test.htm', mimeType: 'text/html' })} />)
+
+    const iframe = screen.getByTitle('HTML preview: test.htm')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe.getAttribute('src')).toContain('/api/files/preview/test-repo/test.htm')
+  })
+
+  it('does not show HTML preview toggle for non-HTML text file', () => {
+    render(<FilePreview file={textFile('readme.txt', 'Hello world', 'text/plain')} />)
+
+    expect(screen.queryByTitle('Show HTML source')).not.toBeInTheDocument()
+    expect(screen.queryByTitle('Preview rendered HTML')).not.toBeInTheDocument()
+    expect(screen.getByText('Hello world')).toBeInTheDocument()
+  })
+
+  it('preserves markdown preview behavior for .md files', () => {
+    render(<FilePreview file={textFile('readme.md', '# Hello', 'text/markdown')} />)
+
+    const toggleButton = screen.getByTitle('Show raw markdown')
+    expect(toggleButton).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/file-browser/FilePreview.tsx
+++ b/frontend/src/components/file-browser/FilePreview.tsx
@@ -2,9 +2,11 @@ import { useState, useCallback, useRef, useEffect, memo } from 'react'
 import { Button } from '@/components/ui/button'
 import { Download, X, Edit3, Save, X as XIcon, WrapText, Eye, Code } from 'lucide-react'
 import type { FileInfo } from '@/types/files'
-import { getFileApiUrl } from '@/api/files'
+import { getFileApiUrl, getFilePreviewUrl } from '@/api/files'
 import { VirtualizedTextView, type VirtualizedTextViewHandle } from '@/components/ui/virtualized-text-view'
 import { MarkdownRenderer } from './MarkdownRenderer'
+import { HtmlPreviewFrame } from '@/components/html-preview/HtmlPreviewFrame'
+import { isHtmlPath } from '@/lib/htmlArtifacts'
 
 
 const VIRTUALIZATION_THRESHOLD_BYTES = 50_000
@@ -21,6 +23,7 @@ interface FilePreviewProps {
 
 export const FilePreview = memo(function FilePreview({ file, hideHeader = false, isMobileModal = false, onCloseModal, onFileSaved, initialLineNumber }: FilePreviewProps) {
   const isMarkdownFile = file.name.toLowerCase().endsWith('.md') || file.name.toLowerCase().endsWith('.mdx') || file.mimeType === 'text/markdown'
+  const isHtmlFile = isHtmlPath(file.name) || file.mimeType === 'text/html'
   
   const [viewMode, setViewMode] = useState<'preview' | 'edit'>('preview')
   const [editContent, setEditContent] = useState('')
@@ -29,6 +32,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
   const [highlightedLine, setHighlightedLine] = useState<number | undefined>(initialLineNumber)
   const [lineWrap, setLineWrap] = useState(true)
   const [markdownPreview, setMarkdownPreview] = useState(isMarkdownFile)
+  const [htmlPreview, setHtmlPreview] = useState(isHtmlFile)
   const [isLoadingAllContent, setIsLoadingAllContent] = useState(false)
   const [fullContentLoaded, setFullContentLoaded] = useState(false)
   const [fullContent, setFullContent] = useState<string | null>(null)
@@ -42,9 +46,10 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
   useEffect(() => {
     setFullContentLoaded(false)
     setMarkdownPreview(isMarkdownFile)
+    setHtmlPreview(isHtmlFile)
     setFullContent(null)
     setLocalMdContent(null)
-  }, [file.path, isMarkdownFile])
+  }, [file.path, isMarkdownFile, isHtmlFile])
   
   useEffect(() => {
     if (shouldVirtualize && isMarkdownFile && markdownPreview && !isMarkdownTooLarge && !fullContentLoaded) {
@@ -227,7 +232,16 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
     }
 
     if (shouldVirtualize && isTextFile) {
+      const showHtmlPreview = isHtmlFile && htmlPreview && viewMode !== 'edit'
       const showMarkdownPreview = isMarkdownFile && markdownPreview && viewMode !== 'edit'
+      
+      if (showHtmlPreview) {
+        return (
+          <div className="h-[calc(100vh-12rem)] min-h-[480px] rounded border border-border overflow-hidden bg-white">
+            <HtmlPreviewFrame title={`HTML preview: ${file.name}`} src={getFilePreviewUrl(file.path)} />
+          </div>
+        )
+      }
       
       return (
         <>
@@ -283,6 +297,14 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
             autoFocus
             data-file-editor="true"
           />
+        )
+      }
+
+      if (isHtmlFile && htmlPreview) {
+        return (
+          <div className="h-[calc(100vh-12rem)] min-h-[480px] rounded border border-border overflow-hidden bg-white">
+            <HtmlPreviewFrame title={`HTML preview: ${file.name}`} src={getFilePreviewUrl(file.path)} />
+          </div>
         )
       }
       
@@ -392,8 +414,20 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
                   {markdownPreview ? <Code className="w-3 h-3" /> : <Eye className="w-3 h-3" />}
                 </Button>
               )}
+
+              {isHtmlFile && viewMode !== 'edit' && (
+                <Button 
+                  variant="outline" 
+                  size="sm" 
+                  onClick={(e) => { e.stopPropagation(); e.preventDefault(); setHtmlPreview(!htmlPreview) }} 
+                  className={`h-7 w-7 p-0 ${htmlPreview ? 'bg-primary text-primary-foreground' : ''}`}
+                  title={htmlPreview ? "Show HTML source" : "Preview rendered HTML"}
+                >
+                  {htmlPreview ? <Code className="w-3 h-3" /> : <Eye className="w-3 h-3" />}
+                </Button>
+              )}
               
-              {isTextFile && !markdownPreview && (
+              {isTextFile && !markdownPreview && !htmlPreview && (
                 <Button 
                   variant="outline" 
                   size="sm" 

--- a/frontend/src/components/file-browser/FilePreview.tsx
+++ b/frontend/src/components/file-browser/FilePreview.tsx
@@ -219,6 +219,12 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
     ['application/json', 'application/xml', 'text/javascript', 'text/typescript'].includes(file.mimeType || '')
 
   const renderContent = () => {
+    const htmlPreviewFrame = (
+      <div className="h-[calc(100vh-12rem)] min-h-[480px] rounded border border-border overflow-hidden bg-white">
+        <HtmlPreviewFrame title={`HTML preview: ${file.name}`} src={getFilePreviewUrl(file.path)} />
+      </div>
+    )
+
     if (file.mimeType?.startsWith('image/')) {
       return (
         <div className="flex justify-center p-4">
@@ -236,11 +242,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
       const showMarkdownPreview = isMarkdownFile && markdownPreview && viewMode !== 'edit'
       
       if (showHtmlPreview) {
-        return (
-          <div className="h-[calc(100vh-12rem)] min-h-[480px] rounded border border-border overflow-hidden bg-white">
-            <HtmlPreviewFrame title={`HTML preview: ${file.name}`} src={getFilePreviewUrl(file.path)} />
-          </div>
-        )
+        return htmlPreviewFrame
       }
       
       return (
@@ -301,11 +303,7 @@ export const FilePreview = memo(function FilePreview({ file, hideHeader = false,
       }
 
       if (isHtmlFile && htmlPreview) {
-        return (
-          <div className="h-[calc(100vh-12rem)] min-h-[480px] rounded border border-border overflow-hidden bg-white">
-            <HtmlPreviewFrame title={`HTML preview: ${file.name}`} src={getFilePreviewUrl(file.path)} />
-          </div>
-        )
+        return htmlPreviewFrame
       }
       
       try {

--- a/frontend/src/components/file-browser/MobileFilePreviewModal.tsx
+++ b/frontend/src/components/file-browser/MobileFilePreviewModal.tsx
@@ -1,9 +1,11 @@
 import { memo, useCallback, useState, useEffect, useRef } from "react";
 import { FilePreview } from "./FilePreview";
 import { FullscreenSheet } from "@/components/ui/fullscreen-sheet";
+import { Button } from "@/components/ui/button";
 import type { FileInfo } from "@/types/files";
 import { GPU_ACCELERATED_STYLE, MODAL_TRANSITION_MS } from "@/lib/utils";
 import { useSwipeBack } from "@/hooks/useMobile";
+import { X } from "lucide-react";
 
 interface MobileFilePreviewModalProps {
   isOpen: boolean;
@@ -69,13 +71,24 @@ export const MobileFilePreviewModal = memo(function MobileFilePreviewModal({
 
   return (
     <div ref={containerRef} style={{ isolation: 'isolate' }}>
-      <FullscreenSheet style={{ ...GPU_ACCELERATED_STYLE, ...swipeStyles }}>
-        <div className={`h-full overflow-hidden bg-background pt-safe ${showFilePreviewHeader ? "" : "pb-8"}`}>
+      <FullscreenSheet className="h-dvh max-h-dvh w-screen max-w-screen overflow-hidden" style={{ ...GPU_ACCELERATED_STYLE, ...swipeStyles }}>
+        <div className="flex h-full min-h-0 flex-1 flex-col overflow-hidden bg-background pt-safe">
+          {!showFilePreviewHeader && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={handleClose}
+              aria-label="Close preview"
+              className="absolute right-2 top-2 z-10"
+            >
+              <X className="size-4" />
+            </Button>
+          )}
           <FilePreview
             key={localFile.path}
             file={localFile}
             hideHeader={!showFilePreviewHeader}
-            isMobileModal={showFilePreviewHeader}
+            isMobileModal
             onCloseModal={handleClose}
           />
         </div>

--- a/frontend/src/components/html-preview/HtmlArtifactPanel.test.tsx
+++ b/frontend/src/components/html-preview/HtmlArtifactPanel.test.tsx
@@ -62,7 +62,7 @@ describe('HtmlArtifactPanel', () => {
     expect(iframe).toBeInTheDocument()
     expect(iframe).toHaveAttribute('src')
     expect(iframe.getAttribute('src')).toContain('/api/files/preview/')
-    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
+    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts allow-same-origin')
   })
 
   it('does not include allow-same-origin in sandbox', () => {

--- a/frontend/src/components/html-preview/HtmlArtifactPanel.test.tsx
+++ b/frontend/src/components/html-preview/HtmlArtifactPanel.test.tsx
@@ -42,7 +42,8 @@ describe('HtmlArtifactPanel', () => {
 
     const iframe = screen.getByTitle('Test Preview')
     expect(iframe).toBeInTheDocument()
-    expect(iframe).toHaveAttribute('srcdoc', '<h1>Hello World</h1>')
+    expect(iframe.getAttribute('srcdoc')).toContain('<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">')
+    expect(iframe.getAttribute('srcdoc')).toContain('<h1>Hello World</h1>')
     expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
   })
 
@@ -146,21 +147,6 @@ describe('HtmlArtifactPanel', () => {
 
     const sheetRoot = container.querySelector('.fixed.inset-0')
     expect(sheetRoot).toBeInTheDocument()
-  })
-
-  it('shows source label (File artifact / Inline artifact)', () => {
-    const inlineArtifact = createInlineArtifact()
-    render(
-      <HtmlArtifactPanel
-        artifact={inlineArtifact}
-        isFullscreen={false}
-        isMobile={false}
-        onClose={() => {}}
-        onToggleFullscreen={() => {}}
-      />,
-    )
-
-    expect(screen.getByText('(Inline artifact)')).toBeInTheDocument()
   })
 
   it('returns null when artifact is null', () => {

--- a/frontend/src/components/html-preview/HtmlArtifactPanel.test.tsx
+++ b/frontend/src/components/html-preview/HtmlArtifactPanel.test.tsx
@@ -1,0 +1,211 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { HtmlArtifactPanel } from './HtmlArtifactPanel'
+import type { HtmlArtifact } from '@/lib/htmlArtifacts'
+
+vi.mock('@/api/files', () => ({
+  getFilePreviewUrl: (path: string) => `/api/files/preview/${encodeURIComponent(path)}`,
+}))
+
+function createInlineArtifact(overrides?: Partial<HtmlArtifact>): HtmlArtifact {
+  return {
+    id: 'test-1',
+    title: 'Test Preview',
+    source: 'inline',
+    html: '<h1>Hello World</h1>',
+    ...overrides,
+  }
+}
+
+function createFileArtifact(overrides?: Partial<HtmlArtifact>): HtmlArtifact {
+  return {
+    id: 'test-2',
+    title: 'File Preview',
+    source: 'file',
+    path: 'my-repo/dist/index.html',
+    ...overrides,
+  }
+}
+
+describe('HtmlArtifactPanel', () => {
+  it('renders inline artifact with srcdoc and sandbox attribute', () => {
+    const artifact = createInlineArtifact()
+    render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={false}
+        isMobile={false}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const iframe = screen.getByTitle('Test Preview')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe).toHaveAttribute('srcdoc', '<h1>Hello World</h1>')
+    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
+  })
+
+  it('renders file artifact iframe with src pointing to preview API', () => {
+    const artifact = createFileArtifact()
+    render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={false}
+        isMobile={false}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const iframe = screen.getByTitle('File Preview')
+    expect(iframe).toBeInTheDocument()
+    expect(iframe).toHaveAttribute('src')
+    expect(iframe.getAttribute('src')).toContain('/api/files/preview/')
+    expect(iframe).toHaveAttribute('sandbox', 'allow-scripts')
+  })
+
+  it('does not include allow-same-origin in sandbox', () => {
+    const artifact = createInlineArtifact()
+    render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={false}
+        isMobile={false}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const iframe = screen.getByTitle('Test Preview')
+    const sandbox = iframe.getAttribute('sandbox')
+    expect(sandbox).not.toContain('allow-same-origin')
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn()
+    const artifact = createInlineArtifact()
+    render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={false}
+        isMobile={false}
+        onClose={onClose}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const closeButton = screen.getByLabelText('Close preview')
+    fireEvent.click(closeButton)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders fullscreen toggle button on desktop', () => {
+    const artifact = createInlineArtifact()
+    render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={false}
+        isMobile={false}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const toggleButton = screen.getByLabelText('Enter fullscreen')
+    expect(toggleButton).toBeInTheDocument()
+  })
+
+  it('renders FullscreenSheet on mobile', () => {
+    const artifact = createInlineArtifact()
+    const { container } = render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={false}
+        isMobile={true}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const sheetRoot = container.querySelector('.fixed.inset-0')
+    expect(sheetRoot).toBeInTheDocument()
+  })
+
+  it('renders FullscreenSheet when isFullscreen is true (desktop)', () => {
+    const artifact = createInlineArtifact()
+    const { container } = render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={true}
+        isMobile={false}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const sheetRoot = container.querySelector('.fixed.inset-0')
+    expect(sheetRoot).toBeInTheDocument()
+  })
+
+  it('shows source label (File artifact / Inline artifact)', () => {
+    const inlineArtifact = createInlineArtifact()
+    render(
+      <HtmlArtifactPanel
+        artifact={inlineArtifact}
+        isFullscreen={false}
+        isMobile={false}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    expect(screen.getByText('(Inline artifact)')).toBeInTheDocument()
+  })
+
+  it('returns null when artifact is null', () => {
+    const { container } = render(
+      <HtmlArtifactPanel
+        artifact={null}
+        isFullscreen={false}
+        isMobile={false}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('shows desktop side-panel classes on desktop', () => {
+    const artifact = createInlineArtifact()
+    const { container } = render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={false}
+        isMobile={false}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const panel = container.querySelector('.hidden.md\\:flex')
+    expect(panel).toBeInTheDocument()
+  })
+
+  it('does not show desktop side panel on mobile', () => {
+    const artifact = createInlineArtifact()
+    const { container } = render(
+      <HtmlArtifactPanel
+        artifact={artifact}
+        isFullscreen={false}
+        isMobile={true}
+        onClose={() => {}}
+        onToggleFullscreen={() => {}}
+      />,
+    )
+
+    const panel = container.querySelector('.hidden.md\\:flex')
+    expect(panel).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/html-preview/HtmlArtifactPanel.tsx
+++ b/frontend/src/components/html-preview/HtmlArtifactPanel.tsx
@@ -1,0 +1,96 @@
+import { getFilePreviewUrl } from '@/api/files'
+import {
+  FullscreenSheet,
+  FullscreenSheetHeader,
+  FullscreenSheetContent,
+} from '@/components/ui/fullscreen-sheet'
+import { Button } from '@/components/ui/button'
+import { X, Maximize2, Minimize2 } from 'lucide-react'
+import { HtmlPreviewFrame } from './HtmlPreviewFrame'
+import type { HtmlArtifact } from '@/lib/htmlArtifacts'
+
+interface HtmlArtifactPanelProps {
+  artifact: HtmlArtifact | null
+  isFullscreen: boolean
+  isMobile: boolean
+  onClose: () => void
+  onToggleFullscreen: () => void
+}
+
+export function HtmlArtifactPanel({
+  artifact,
+  isFullscreen,
+  isMobile,
+  onClose,
+  onToggleFullscreen,
+}: HtmlArtifactPanelProps) {
+  if (!artifact) return null
+
+  const previewSrc = artifact.source === 'file' && artifact.path
+    ? getFilePreviewUrl(artifact.path)
+    : undefined
+  const previewSrcDoc = artifact.source === 'inline' ? artifact.html : undefined
+  const title = artifact.title
+  const sourceLabel = artifact.source === 'file' ? 'File artifact' : 'Inline artifact'
+
+  const header = (
+    <div className="flex items-center justify-between px-4 py-2">
+      <div className="flex items-center gap-2 min-w-0">
+        <span className="text-sm font-medium truncate">{title}</span>
+        <span className="text-xs text-muted-foreground shrink-0">({sourceLabel})</span>
+      </div>
+      <div className="flex items-center gap-1">
+        {!isMobile && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onToggleFullscreen}
+            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
+          >
+            {isFullscreen ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
+          </Button>
+        )}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onClose}
+          aria-label="Close preview"
+        >
+          <X className="size-4" />
+        </Button>
+      </div>
+    </div>
+  )
+
+  const frame = (
+    <HtmlPreviewFrame
+      title={title}
+      src={previewSrc}
+      srcDoc={previewSrcDoc}
+    />
+  )
+
+  if (isMobile || isFullscreen) {
+    return (
+      <FullscreenSheet>
+        <FullscreenSheetHeader>
+          {header}
+        </FullscreenSheetHeader>
+        <FullscreenSheetContent>
+          {frame}
+        </FullscreenSheetContent>
+      </FullscreenSheet>
+    )
+  }
+
+  return (
+    <div className="hidden md:flex w-[45%] max-w-[720px] min-w-[360px] border-l border-border bg-background flex-col">
+      <div className="flex-shrink-0 border-b border-border">
+        {header}
+      </div>
+      <div className="flex-1 min-h-0">
+        {frame}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/html-preview/HtmlArtifactPanel.tsx
+++ b/frontend/src/components/html-preview/HtmlArtifactPanel.tsx
@@ -1,7 +1,6 @@
 import { getFilePreviewUrl } from '@/api/files'
 import {
   FullscreenSheet,
-  FullscreenSheetHeader,
   FullscreenSheetContent,
 } from '@/components/ui/fullscreen-sheet'
 import { Button } from '@/components/ui/button'
@@ -31,34 +30,27 @@ export function HtmlArtifactPanel({
     : undefined
   const previewSrcDoc = artifact.source === 'inline' ? artifact.html : undefined
   const title = artifact.title
-  const sourceLabel = artifact.source === 'file' ? 'File artifact' : 'Inline artifact'
 
-  const header = (
-    <div className="flex items-center justify-between px-4 py-2">
-      <div className="flex items-center gap-2 min-w-0">
-        <span className="text-sm font-medium truncate">{title}</span>
-        <span className="text-xs text-muted-foreground shrink-0">({sourceLabel})</span>
-      </div>
-      <div className="flex items-center gap-1">
-        {!isMobile && (
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={onToggleFullscreen}
-            aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
-          >
-            {isFullscreen ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
-          </Button>
-        )}
+  const headerButtons = (
+    <div className="flex items-center gap-1">
+      {!isMobile && (
         <Button
           variant="ghost"
           size="icon-sm"
-          onClick={onClose}
-          aria-label="Close preview"
+          onClick={onToggleFullscreen}
+          aria-label={isFullscreen ? 'Exit fullscreen' : 'Enter fullscreen'}
         >
-          <X className="size-4" />
+          {isFullscreen ? <Minimize2 className="size-4" /> : <Maximize2 className="size-4" />}
         </Button>
-      </div>
+      )}
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={onClose}
+        aria-label="Close preview"
+      >
+        <X className="size-4" />
+      </Button>
     </div>
   )
 
@@ -72,11 +64,11 @@ export function HtmlArtifactPanel({
 
   if (isMobile || isFullscreen) {
     return (
-      <FullscreenSheet>
-        <FullscreenSheetHeader>
-          {header}
-        </FullscreenSheetHeader>
-        <FullscreenSheetContent>
+      <FullscreenSheet className="h-dvh max-h-dvh w-screen max-w-screen overflow-hidden">
+        <FullscreenSheetContent className="relative h-full max-h-full w-full max-w-full">
+          <div className="absolute top-2 right-2 z-10">
+            {headerButtons}
+          </div>
           {frame}
         </FullscreenSheetContent>
       </FullscreenSheet>
@@ -84,12 +76,12 @@ export function HtmlArtifactPanel({
   }
 
   return (
-    <div className="hidden md:flex w-[45%] max-w-[720px] min-w-[360px] border-l border-border bg-background flex-col">
-      <div className="flex-shrink-0 border-b border-border">
-        {header}
-      </div>
+    <div className="hidden md:flex w-[45%] max-w-[720px] min-w-[360px] border-l border-border bg-background flex-col relative">
       <div className="flex-1 min-h-0">
         {frame}
+      </div>
+      <div className="absolute top-2 right-2 z-10">
+        {headerButtons}
       </div>
     </div>
   )

--- a/frontend/src/components/html-preview/HtmlPreviewFrame.tsx
+++ b/frontend/src/components/html-preview/HtmlPreviewFrame.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/lib/utils'
+import { normalizeHtmlPreviewDocument } from '@/lib/htmlArtifacts'
 
 interface HtmlPreviewFrameProps {
   title: string
@@ -9,14 +10,16 @@ interface HtmlPreviewFrameProps {
 
 export function HtmlPreviewFrame({ title, src, srcDoc, className }: HtmlPreviewFrameProps) {
   const sandbox = src ? 'allow-scripts allow-same-origin' : 'allow-scripts'
+  const normalizedSrcDoc = srcDoc ? normalizeHtmlPreviewDocument(srcDoc) : undefined
   return (
     <iframe
       title={title}
       src={src}
-      srcDoc={srcDoc}
+      srcDoc={normalizedSrcDoc}
       sandbox={sandbox}
       referrerPolicy="no-referrer"
-      className={cn('h-full w-full border-0 bg-white', className)}
+      scrolling="yes"
+      className={cn('block h-full max-h-full min-h-0 w-full max-w-full border-0 bg-white', className)}
     />
   )
 }

--- a/frontend/src/components/html-preview/HtmlPreviewFrame.tsx
+++ b/frontend/src/components/html-preview/HtmlPreviewFrame.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils'
+
+interface HtmlPreviewFrameProps {
+  title: string
+  src?: string
+  srcDoc?: string
+  className?: string
+}
+
+export function HtmlPreviewFrame({ title, src, srcDoc, className }: HtmlPreviewFrameProps) {
+  return (
+    <iframe
+      title={title}
+      src={src}
+      srcDoc={srcDoc}
+      sandbox="allow-scripts"
+      referrerPolicy="no-referrer"
+      className={cn('h-full w-full border-0 bg-white', className)}
+    />
+  )
+}

--- a/frontend/src/components/html-preview/HtmlPreviewFrame.tsx
+++ b/frontend/src/components/html-preview/HtmlPreviewFrame.tsx
@@ -8,12 +8,13 @@ interface HtmlPreviewFrameProps {
 }
 
 export function HtmlPreviewFrame({ title, src, srcDoc, className }: HtmlPreviewFrameProps) {
+  const sandbox = src ? 'allow-scripts allow-same-origin' : 'allow-scripts'
   return (
     <iframe
       title={title}
       src={src}
       srcDoc={srcDoc}
-      sandbox="allow-scripts"
+      sandbox={sandbox}
       referrerPolicy="no-referrer"
       className={cn('h-full w-full border-0 bg-white', className)}
     />

--- a/frontend/src/components/html-preview/PreviewHtmlButton.tsx
+++ b/frontend/src/components/html-preview/PreviewHtmlButton.tsx
@@ -1,0 +1,21 @@
+import { cn } from '@/lib/utils'
+
+interface PreviewHtmlButtonProps {
+  onClick: () => void
+  className?: string
+}
+
+export function PreviewHtmlButton({ onClick, className }: PreviewHtmlButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        'rounded bg-card hover:bg-card-hover text-muted-foreground hover:text-foreground text-xs',
+        className,
+      )}
+      title="Preview HTML artifact"
+    >
+      Preview HTML
+    </button>
+  )
+}

--- a/frontend/src/components/message/CodePreview.test.tsx
+++ b/frontend/src/components/message/CodePreview.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CodePreview } from './CodePreview'
+
+const mocks = vi.hoisted(() => ({
+  useMobile: vi.fn(() => false),
+}))
+
+vi.mock('@/hooks/useMobile', () => ({
+  useMobile: () => mocks.useMobile(),
+}))
+
+describe('CodePreview', () => {
+  beforeEach(() => {
+    mocks.useMobile.mockReturnValue(false)
+  })
+
+  it('shows artifact button for .html files', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    render(
+      <CodePreview
+        fileName="dist/report.html"
+        content="<h1>Report</h1>"
+        onHtmlArtifactOpen={onHtmlArtifactOpen}
+      />
+    )
+
+    const button = screen.getByTitle('Preview HTML artifact')
+    expect(button).toBeInTheDocument()
+  })
+
+  it('calls onHtmlArtifactOpen with file source when artifact button is clicked', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    render(
+      <CodePreview
+        fileName="dist/report.html"
+        content="<h1>Report</h1>"
+        onHtmlArtifactOpen={onHtmlArtifactOpen}
+      />
+    )
+
+    const button = screen.getByTitle('Preview HTML artifact')
+    fireEvent.click(button)
+
+    expect(onHtmlArtifactOpen).toHaveBeenCalledWith({
+      source: 'file',
+      path: 'dist/report.html',
+      title: expect.stringContaining('report'),
+    })
+  })
+
+  it('shows artifact button for .htm files', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    render(
+      <CodePreview
+        fileName="page.htm"
+        content="<h1>Hello</h1>"
+        onHtmlArtifactOpen={onHtmlArtifactOpen}
+      />
+    )
+
+    expect(screen.getByTitle('Preview HTML artifact')).toBeInTheDocument()
+  })
+
+  it('does not show artifact button for .ts files', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    render(
+      <CodePreview
+        fileName="component.ts"
+        content="const x = 1"
+        onHtmlArtifactOpen={onHtmlArtifactOpen}
+      />
+    )
+
+    expect(screen.queryByTitle('Preview HTML artifact')).not.toBeInTheDocument()
+  })
+
+  it('shows show-more button for large files', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`)
+    const content = lines.join('\n')
+
+    render(
+      <CodePreview
+        fileName="large.ts"
+        content={content}
+      />
+    )
+
+    expect(screen.getByText(/10 more lines/)).toBeInTheDocument()
+  })
+
+  it('uses inline fallback when fileName is empty', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    render(
+      <CodePreview
+        fileName=""
+        content="<h1>Hello</h1>"
+        onHtmlArtifactOpen={onHtmlArtifactOpen}
+      />
+    )
+
+    const button = screen.getByTitle('Preview HTML artifact')
+    fireEvent.click(button)
+
+    expect(onHtmlArtifactOpen).toHaveBeenCalledWith({
+      source: 'inline',
+      html: '<h1>Hello</h1>',
+      title: 'HTML artifact',
+    })
+  })
+})

--- a/frontend/src/components/message/CodePreview.tsx
+++ b/frontend/src/components/message/CodePreview.tsx
@@ -4,6 +4,7 @@ import { useMobile } from '@/hooks/useMobile'
 import { cn } from '@/lib/utils'
 import { isHtmlPath } from '@/lib/htmlArtifacts'
 import type { OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
+import { PreviewHtmlButton } from '@/components/html-preview/PreviewHtmlButton'
 
 interface CodePreviewProps {
   fileName: string
@@ -92,13 +93,7 @@ export function CodePreview({ fileName, content, onHtmlArtifactOpen }: CodePrevi
         <span className="font-medium truncate flex-1">{extractFileFromPath(fileName)}</span>
         <div className="flex items-center gap-1 flex-shrink-0">
           {isHtmlFile && onHtmlArtifactOpen && (
-            <button
-              onClick={handleHtmlArtifact}
-              className="px-2 py-1 rounded bg-card hover:bg-card-hover text-muted-foreground hover:text-foreground text-xs"
-              title="Preview HTML artifact"
-            >
-              Preview HTML
-            </button>
+            <PreviewHtmlButton onClick={handleHtmlArtifact} className="px-2 py-1" />
           )}
           <CopyButton content={content} title="Copy" iconSize="sm" variant="ghost" />
         </div>

--- a/frontend/src/components/message/CodePreview.tsx
+++ b/frontend/src/components/message/CodePreview.tsx
@@ -2,10 +2,13 @@ import React from 'react'
 import { CopyButton } from '@/components/ui/copy-button'
 import { useMobile } from '@/hooks/useMobile'
 import { cn } from '@/lib/utils'
+import { isHtmlPath } from '@/lib/htmlArtifacts'
+import type { OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
 
 interface CodePreviewProps {
   fileName: string
   content: string
+  onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void
 }
 
 const INITIAL_CODE_LINES = 20
@@ -57,7 +60,7 @@ function detectLanguage(fileName: string): string {
   return langMap[ext || ''] || 'plaintext'
 }
 
-export function CodePreview({ fileName, content }: CodePreviewProps) {
+export function CodePreview({ fileName, content, onHtmlArtifactOpen }: CodePreviewProps) {
   const isMobile = useMobile()
   const [showMore, setShowMore] = React.useState(false)
 
@@ -72,11 +75,33 @@ export function CodePreview({ fileName, content }: CodePreviewProps) {
     ? lines.slice(0, INITIAL_CODE_LINES).join('\n')
     : content
 
+  const isHtmlFile = fileName ? isHtmlPath(fileName) : true
+
+  const handleHtmlArtifact = () => {
+    if (!onHtmlArtifactOpen) return
+    if (fileName) {
+      onHtmlArtifactOpen({ source: 'file', path: fileName, title: extractFileFromPath(fileName) })
+    } else {
+      onHtmlArtifactOpen({ source: 'inline', html: content, title: 'HTML artifact' })
+    }
+  }
+
   return (
     <div className="flex flex-col bg-background">
       <div className="px-3 py-2 bg-muted/30 border-b border-border/50 flex items-center justify-between text-xs">
         <span className="font-medium truncate flex-1">{extractFileFromPath(fileName)}</span>
-        <CopyButton content={content} title="Copy" iconSize="sm" variant="ghost" className="flex-shrink-0" />
+        <div className="flex items-center gap-1 flex-shrink-0">
+          {isHtmlFile && onHtmlArtifactOpen && (
+            <button
+              onClick={handleHtmlArtifact}
+              className="px-2 py-1 rounded bg-card hover:bg-card-hover text-muted-foreground hover:text-foreground text-xs"
+              title="Preview HTML artifact"
+            >
+              Preview HTML
+            </button>
+          )}
+          <CopyButton content={content} title="Copy" iconSize="sm" variant="ghost" />
+        </div>
       </div>
 
       <div className={cn('overflow-y-auto', isMobile ? 'max-h-64' : 'max-h-96')}>

--- a/frontend/src/components/message/FileToolRender.tsx
+++ b/frontend/src/components/message/FileToolRender.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import type { components } from '@/api/opencode-types'
+import type { OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
 import { useSettings } from '@/hooks/useSettings'
 import { DiffStats } from './DiffStats'
 import { ContentDiffViewer } from './ContentDiffViewer'
@@ -60,9 +61,10 @@ interface FileToolRenderProps {
   content?: string
   toolName: string
   onFileClick?: (filePath: string, lineNumber?: number) => void
+  onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void
 }
 
-export function FileToolRender({ part, filediff, filePath, content, toolName, onFileClick }: FileToolRenderProps) {
+export function FileToolRender({ part, filediff, filePath, content, toolName, onFileClick, onHtmlArtifactOpen }: FileToolRenderProps) {
   const { preferences } = useSettings()
   const isReadTool = toolName === 'Read'
   const isEditTool = toolName === 'Edit'
@@ -119,21 +121,21 @@ export function FileToolRender({ part, filediff, filePath, content, toolName, on
       {expanded && hasExpandableContent && (
         <div className="bg-card p-0">
           {filediff && <ContentDiffViewer before={filediff.before} after={filediff.after} />}
-          {content && !filediff && <CodePreview fileName={filePath || ''} content={content} />}
+          {content && !filediff && <CodePreview fileName={filePath || ''} content={content} onHtmlArtifactOpen={onHtmlArtifactOpen} />}
         </div>
       )}
     </div>
   )
 }
 
-export function getToolSpecificRender(part: ToolPart, onFileClick?: (filePath: string) => void): React.ReactElement | null {
+export function getToolSpecificRender(part: ToolPart, onFileClick?: (filePath: string) => void, onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void): React.ReactElement | null {
   if (part.state.status !== 'completed') return null
 
   if (part.tool === 'edit') {
     const filediff = part.state.metadata?.filediff
     const filePath = part.state.input?.filePath as string | undefined
     if (filediff && isFileDiff(filediff)) {
-      return <FileToolRender part={part} filediff={filediff} filePath={filePath} toolName="Edit" onFileClick={onFileClick} />
+      return <FileToolRender part={part} filediff={filediff} filePath={filePath} toolName="Edit" onFileClick={onFileClick} onHtmlArtifactOpen={onHtmlArtifactOpen} />
     }
   }
 
@@ -141,14 +143,14 @@ export function getToolSpecificRender(part: ToolPart, onFileClick?: (filePath: s
     const filePath = part.state.input?.filePath as string | undefined
     const content = part.state.input?.content as string | undefined
     if (filePath) {
-      return <FileToolRender part={part} filePath={filePath} content={content} toolName="Write" onFileClick={onFileClick} />
+      return <FileToolRender part={part} filePath={filePath} content={content} toolName="Write" onFileClick={onFileClick} onHtmlArtifactOpen={onHtmlArtifactOpen} />
     }
   }
 
   if (part.tool === 'read') {
     const filePath = part.state.input?.filePath as string | undefined
     if (filePath) {
-      return <FileToolRender part={part} filePath={filePath} toolName="Read" onFileClick={onFileClick} />
+      return <FileToolRender part={part} filePath={filePath} toolName="Read" onFileClick={onFileClick} onHtmlArtifactOpen={onHtmlArtifactOpen} />
     }
   }
 

--- a/frontend/src/components/message/MessagePart.tsx
+++ b/frontend/src/components/message/MessagePart.tsx
@@ -14,6 +14,8 @@ type RetryPartType = components['schemas']['RetryPart']
 
 type Part = components['schemas']['Part']
 
+import type { OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
+
 interface MessagePartProps {
   part: Part
   role?: string
@@ -21,6 +23,7 @@ interface MessagePartProps {
   partIndex?: number
   onFileClick?: (filePath: string, lineNumber?: number) => void
   onChildSessionClick?: (sessionId: string) => void
+  onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void
   messageTextContent?: string
 }
 
@@ -102,7 +105,7 @@ function TTSButton({ messageId, content, className = "" }: TTSButtonProps) {
   )
 }
 
-export const MessagePart = memo(function MessagePart({ part, role, allParts, partIndex, onFileClick, onChildSessionClick, messageTextContent }: MessagePartProps) {
+export const MessagePart = memo(function MessagePart({ part, role, allParts, partIndex, onFileClick, onChildSessionClick, onHtmlArtifactOpen, messageTextContent }: MessagePartProps) {
   const { preferences } = useSettings()
   const simpleChatMode = preferences?.simpleChatMode ?? false
   const showReasoning = preferences?.showReasoning ?? false
@@ -118,13 +121,13 @@ export const MessagePart = memo(function MessagePart({ part, role, allParts, par
           return null
         }
       }
-      return <TextPart part={part} />
+      return <TextPart part={part} onHtmlArtifactOpen={onHtmlArtifactOpen} />
     case 'patch':
       if (simpleChatMode) return null
       return <PatchPart part={part} onFileClick={onFileClick} />
     case 'tool':
       if (simpleChatMode && part.tool !== 'task') return null
-      return <ToolCallPart part={part} onFileClick={onFileClick} onChildSessionClick={onChildSessionClick} />
+      return <ToolCallPart part={part} onFileClick={onFileClick} onChildSessionClick={onChildSessionClick} onHtmlArtifactOpen={onHtmlArtifactOpen} />
     case 'reasoning':
       if (simpleChatMode || !showReasoning) return null
       return (

--- a/frontend/src/components/message/MessageThread.tsx
+++ b/frontend/src/components/message/MessageThread.tsx
@@ -8,6 +8,7 @@ import type { Message, Part, MessageWithParts } from '@/api/types'
 import { useSessionStatusForSession } from '@/stores/sessionStatusStore'
 import { useSessionTodos } from '@/stores/sessionTodosStore'
 import { useSettings } from '@/hooks/useSettings'
+import type { OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
 import type { components } from '@/api/opencode-types'
 import type { Todo } from '@/components/message/SessionTodoDisplay'
 import type { OpenCodeError } from '@/lib/opencode-errors'
@@ -27,6 +28,7 @@ interface MessageThreadProps {
   messages?: MessageWithParts[]
   onFileClick?: (filePath: string, lineNumber?: number) => void
   onChildSessionClick?: (sessionId: string) => void
+  onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void
   onUndoMessage?: (restoredPrompt: string) => void
   model?: string
 }
@@ -147,6 +149,7 @@ interface MessageRowProps {
   directory?: string
   onFileClick?: (filePath: string, lineNumber?: number) => void
   onChildSessionClick?: (sessionId: string) => void
+  onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void
   handleStartEditUserMessage: (userMessageId: string, assistantMessageId: string) => void
   handleCancelEdit: () => void
   model?: string
@@ -168,6 +171,7 @@ const MessageRow = memo(function MessageRow({
   directory,
   onFileClick,
   onChildSessionClick,
+  onHtmlArtifactOpen,
   handleStartEditUserMessage,
   handleCancelEdit,
   model,
@@ -212,6 +216,7 @@ const MessageRow = memo(function MessageRow({
                 partIndex={partIndex}
                 onFileClick={onFileClick}
                 onChildSessionClick={onChildSessionClick}
+                onHtmlArtifactOpen={onHtmlArtifactOpen}
                 messageTextContent={messageTextContent}
               />
             </div>
@@ -308,6 +313,7 @@ const MessageRow = memo(function MessageRow({
                   partIndex={partIndex}
                   onFileClick={onFileClick}
                   onChildSessionClick={onChildSessionClick}
+                  onHtmlArtifactOpen={onHtmlArtifactOpen}
                   messageTextContent={msg.role === 'assistant' ? messageTextContent : undefined}
                 />
               </div>
@@ -329,6 +335,7 @@ export const MessageThread = memo(function MessageThread({
   messages, 
   onFileClick, 
   onChildSessionClick,
+  onHtmlArtifactOpen,
   onUndoMessage,
   model
 }: MessageThreadProps) {
@@ -442,6 +449,7 @@ export const MessageThread = memo(function MessageThread({
           directory={directory}
           onFileClick={onFileClick}
           onChildSessionClick={onChildSessionClick}
+          onHtmlArtifactOpen={onHtmlArtifactOpen}
           handleStartEditUserMessage={handleStartEditUserMessage}
           handleCancelEdit={handleCancelEdit}
           model={model}

--- a/frontend/src/components/message/TextPart.test.tsx
+++ b/frontend/src/components/message/TextPart.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { TextPart } from './TextPart'
+
+const mocks = vi.hoisted(() => ({
+  useTheme: vi.fn(() => 'dark'),
+}))
+
+vi.mock('@/hooks/useTheme', () => ({
+  useTheme: () => mocks.useTheme(),
+}))
+
+vi.mock('mermaid', () => ({
+  default: {
+    initialize: vi.fn(),
+    render: vi.fn(),
+  },
+}))
+
+const createTextPart = (text: string) => ({
+  type: 'text' as const,
+  text,
+  sessionID: 'test-session',
+  id: 'part-1',
+})
+
+describe('TextPart', () => {
+  beforeEach(() => {
+    mocks.useTheme.mockReturnValue('dark')
+  })
+
+  it('renders HTML fenced code block with artifact button', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    const markdown = 'Here is a page:\n\n```html\n<html><body><h1>Hello artifact</h1></body></html>\n```'
+    const part = createTextPart(markdown)
+
+    render(<TextPart part={part} onHtmlArtifactOpen={onHtmlArtifactOpen} />)
+
+    const button = screen.getByTitle('Preview HTML artifact')
+    expect(button).toBeInTheDocument()
+  })
+
+  it('calls onHtmlArtifactOpen with correct data when artifact button is clicked', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    const markdown = 'Here is a page:\n\n```html\n<html><body><h1>Hello artifact</h1></body></html>\n```'
+    const part = createTextPart(markdown)
+
+    render(<TextPart part={part} onHtmlArtifactOpen={onHtmlArtifactOpen} />)
+
+    const button = screen.getByTitle('Preview HTML artifact')
+    fireEvent.click(button)
+
+    expect(onHtmlArtifactOpen).toHaveBeenCalledWith({
+      source: 'inline',
+      html: '<html><body><h1>Hello artifact</h1></body></html>',
+      title: 'HTML artifact',
+    })
+  })
+
+  it('does not show artifact button for non-HTML code blocks', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    const markdown = '```ts\nconst x = 1\n```'
+    const part = createTextPart(markdown)
+
+    render(<TextPart part={part} onHtmlArtifactOpen={onHtmlArtifactOpen} />)
+
+    expect(screen.queryByTitle('Preview HTML artifact')).not.toBeInTheDocument()
+  })
+
+  it('still shows copy button for code blocks', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    const markdown = '```html\n<p>test</p>\n```'
+    const part = createTextPart(markdown)
+
+    render(<TextPart part={part} onHtmlArtifactOpen={onHtmlArtifactOpen} />)
+
+    expect(screen.getByTitle('Copy code')).toBeInTheDocument()
+  })
+
+  it('preserves leading/trailing whitespace when copying code content', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    const markdown = '```\n  const x = 1\n  \n```'
+    const part = createTextPart(markdown)
+
+    render(<TextPart part={part} onHtmlArtifactOpen={onHtmlArtifactOpen} />)
+
+    const copyButton = screen.getByTitle('Copy code')
+    expect(copyButton).toBeInTheDocument()
+  })
+
+  it('does not show artifact button for mermaid code blocks', () => {
+    const onHtmlArtifactOpen = vi.fn()
+    const markdown = '```mermaid\ngraph TD;\nA-->B;\n```'
+    const part = createTextPart(markdown)
+
+    render(<TextPart part={part} onHtmlArtifactOpen={onHtmlArtifactOpen} />)
+
+    expect(screen.queryByTitle('Preview HTML artifact')).not.toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/message/TextPart.tsx
+++ b/frontend/src/components/message/TextPart.tsx
@@ -7,6 +7,7 @@ import mermaid from 'mermaid'
 import { Maximize2, X, AlertCircle } from 'lucide-react'
 import { CopyButton } from '@/components/ui/copy-button'
 import type { components } from '@/api/opencode-types'
+import type { OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
 import { useTheme } from '@/hooks/useTheme'
 import 'highlight.js/styles/github-dark.css'
 
@@ -14,6 +15,7 @@ type TextPart = components['schemas']['TextPart']
 
 interface TextPartProps {
   part: TextPart
+  onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void
 }
 
 interface MermaidBlockProps {
@@ -146,10 +148,11 @@ function MermaidBlock({ code }: MermaidBlockProps) {
 interface CodeBlockProps {
   children?: React.ReactNode
   className?: string
+  onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void
   [key: string]: unknown
 }
 
-function CodeBlock({ children, className, ...props }: CodeBlockProps) {
+function CodeBlock({ children, className, onHtmlArtifactOpen, ...props }: CodeBlockProps) {
   const extractTextContent = (node: React.ReactNode): string => {
     if (typeof node === 'string') return node
     if (typeof node === 'number') return node.toString()
@@ -163,14 +166,31 @@ function CodeBlock({ children, className, ...props }: CodeBlockProps) {
     return ''
   }
   
-  const codeContent = extractTextContent(children)
+  const rawCodeContent = extractTextContent(children)
+  const codeContent = rawCodeContent.trim()
+
+  const childArray = React.Children.toArray(children)
+  const codeElement = childArray.find((child): child is React.ReactElement => React.isValidElement(child))
+  const codeClassName = codeElement?.props?.className
+  const isHtmlCode = typeof codeClassName === 'string' && (codeClassName.includes('language-html') || codeClassName.includes('language-htm'))
 
   return (
     <div className="relative">
       <pre className={`bg-accent p-1 rounded-lg overflow-x-auto whitespace-pre-wrap break-words border border-border my-4 ${className || ''}`} {...props}>
         {children}
       </pre>
-      <CopyButton content={codeContent} title="Copy code" className="absolute top-2 right-2" />
+      <div className="absolute top-2 right-2 flex gap-1">
+        {isHtmlCode && onHtmlArtifactOpen && (
+          <button
+            onClick={() => onHtmlArtifactOpen({ source: 'inline', html: codeContent, title: 'HTML artifact' })}
+            className="p-1.5 rounded bg-card hover:bg-card-hover text-muted-foreground hover:text-foreground text-xs"
+            title="Preview HTML artifact"
+          >
+            Preview HTML
+          </button>
+        )}
+        <CopyButton content={rawCodeContent} title="Copy code" />
+      </div>
     </div>
   )
 }
@@ -184,7 +204,7 @@ function isMermaidBlockComplete(text: string): boolean {
   return false
 }
 
-export function TextPart({ part }: TextPartProps) {
+export function TextPart({ part, onHtmlArtifactOpen }: TextPartProps) {
   const mermaidComplete = React.useMemo(() => {
     return part.text ? isMermaidBlockComplete(part.text) : false
   }, [part.text])
@@ -234,7 +254,7 @@ export function TextPart({ part }: TextPartProps) {
           },
           pre({ children }) {
             return (
-              <CodeBlock>
+              <CodeBlock onHtmlArtifactOpen={onHtmlArtifactOpen}>
                 {children}
               </CodeBlock>
             )

--- a/frontend/src/components/message/TextPart.tsx
+++ b/frontend/src/components/message/TextPart.tsx
@@ -6,6 +6,7 @@ import rehypeRaw from 'rehype-raw'
 import mermaid from 'mermaid'
 import { Maximize2, X, AlertCircle } from 'lucide-react'
 import { CopyButton } from '@/components/ui/copy-button'
+import { PreviewHtmlButton } from '@/components/html-preview/PreviewHtmlButton'
 import type { components } from '@/api/opencode-types'
 import type { OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
 import { useTheme } from '@/hooks/useTheme'
@@ -181,13 +182,10 @@ function CodeBlock({ children, className, onHtmlArtifactOpen, ...props }: CodeBl
       </pre>
       <div className="absolute top-2 right-2 flex gap-1">
         {isHtmlCode && onHtmlArtifactOpen && (
-          <button
+          <PreviewHtmlButton
             onClick={() => onHtmlArtifactOpen({ source: 'inline', html: codeContent, title: 'HTML artifact' })}
-            className="p-1.5 rounded bg-card hover:bg-card-hover text-muted-foreground hover:text-foreground text-xs"
-            title="Preview HTML artifact"
-          >
-            Preview HTML
-          </button>
+            className="p-1.5"
+          />
         )}
         <CopyButton content={rawCodeContent} title="Copy code" />
       </div>

--- a/frontend/src/components/message/ToolCallPart.tsx
+++ b/frontend/src/components/message/ToolCallPart.tsx
@@ -5,6 +5,7 @@ import { useUserBash } from '@/stores/userBashStore'
 import { useSessionStatusForSession } from '@/stores/sessionStatusStore'
 import { usePermissions, useQuestions } from '@/contexts/EventContext'
 import { detectFileReferences } from '@/lib/fileReferences'
+import type { OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
 import { ExternalLink, Loader2 } from 'lucide-react'
 import { CopyButton } from '@/components/ui/copy-button'
 import { getToolSpecificRender } from './FileToolRender'
@@ -15,6 +16,7 @@ interface ToolCallPartProps {
   part: ToolPart
   onFileClick?: (filePath: string, lineNumber?: number) => void
   onChildSessionClick?: (sessionId: string) => void
+  onHtmlArtifactOpen?: (input: OpenHtmlArtifactInput) => void
   simpleChatMode?: boolean
 }
 
@@ -26,7 +28,7 @@ function getTaskSessionId(part: ToolPart): string | undefined {
   return sessionId
 }
 
-function ClickableJson({ json, onFileClick }: { json: unknown; onFileClick?: (filePath: string) => void }) {
+function ClickableJson({ json, onFileClick }: { json: unknown; onFileClick?: (filePath: string, lineNumber?: number) => void }) {
   const jsonString = JSON.stringify(json, null, 2)
   const references = detectFileReferences(jsonString)
 
@@ -47,7 +49,7 @@ function ClickableJson({ json, onFileClick }: { json: unknown; onFileClick?: (fi
         key={`ref-${index}`}
         onClick={(e) => {
           e.stopPropagation()
-          onFileClick?.(ref.filePath)
+          onFileClick?.(ref.filePath, ref.lineNumber)
         }}
         className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 cursor-pointer underline decoration-dotted"
         title={`Click to open ${ref.filePath}`}
@@ -66,7 +68,7 @@ function ClickableJson({ json, onFileClick }: { json: unknown; onFileClick?: (fi
   return <pre className="bg-accent p-2 rounded text-xs overflow-x-auto whitespace-pre-wrap break-words">{parts}</pre>
 }
 
-export function ToolCallPart({ part, onFileClick, onChildSessionClick }: ToolCallPartProps) {
+export function ToolCallPart({ part, onFileClick, onChildSessionClick, onHtmlArtifactOpen }: ToolCallPartProps) {
   const { preferences } = useSettings()
   const { userBashCommands } = useUserBash()
   const taskSessionId = part.tool === 'task' ? getTaskSessionId(part) : undefined
@@ -219,7 +221,7 @@ export function ToolCallPart({ part, onFileClick, onChildSessionClick }: ToolCal
     return null
   }
 
-  const toolSpecificRender = getToolSpecificRender(part, onFileClick)
+  const toolSpecificRender = getToolSpecificRender(part, onFileClick, onHtmlArtifactOpen)
   if (toolSpecificRender) {
     return toolSpecificRender
   }

--- a/frontend/src/components/settings/GitCredentialDialog.tsx
+++ b/frontend/src/components/settings/GitCredentialDialog.tsx
@@ -6,18 +6,29 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Alert } from '@/components/ui/alert'
+import { Checkbox } from '@/components/ui/checkbox'
+import { MultiSelect, type MultiSelectOption } from '@/components/ui/multi-select'
 import { showToast } from '@/lib/toast'
 import type { GitCredential } from '@/api/types/settings'
+import type { Repo } from '@/api/types'
+
+export interface GitCredentialSaveOptions {
+  makeDefault: boolean
+  repoIds: number[]
+}
 
 interface GitCredentialDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onSave: (credential: GitCredential) => Promise<void>
+  onSave: (credential: GitCredential, options: GitCredentialSaveOptions) => Promise<void>
   credential?: GitCredential
+  repos: Repo[]
+  assignedRepoIds: number[]
+  isDefault: boolean
   isSaving: boolean
 }
 
-export function GitCredentialDialog({ open, onOpenChange, onSave, credential, isSaving }: GitCredentialDialogProps) {
+export function GitCredentialDialog({ open, onOpenChange, onSave, credential, repos, assignedRepoIds, isDefault, isSaving }: GitCredentialDialogProps) {
   const [formData, setFormData] = useState<GitCredential>({
     name: '',
     host: '',
@@ -31,6 +42,8 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
   const [isTesting, setIsTesting] = useState(false)
   const [showPassphraseInput, setShowPassphraseInput] = useState(false)
   const [testPassphrase, setTestPassphrase] = useState('')
+  const [makeDefault, setMakeDefault] = useState(false)
+  const [selectedRepoIds, setSelectedRepoIds] = useState<number[]>([])
 
   const maskToken = (token: string) => {
     if (!token) return ''
@@ -43,6 +56,8 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
       setTokenEdited(false)
       setShowPassphraseInput(false)
       setTestPassphrase('')
+      setMakeDefault(isDefault)
+      setSelectedRepoIds(assignedRepoIds)
       if (credential) {
         setFormData({
           ...credential,
@@ -61,7 +76,16 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
         })
       }
     }
-  }, [open, credential])
+  }, [open, credential, assignedRepoIds, isDefault])
+
+  const normalizedHost = formData.host.toLowerCase().replace(/^https?:\/\//, '').replace(/\/+$/, '')
+  const isGithubPat = formData.type === 'pat' && normalizedHost === 'github.com'
+
+  const repoOptions: MultiSelectOption[] = repos.map((repo) => ({
+    value: String(repo.id),
+    label: repo.repoUrl?.split('/').pop()?.replace('.git', '') || repo.localPath,
+    description: repo.repoUrl || repo.fullPath,
+  }))
 
   const handleSubmit = async (event?: React.MouseEvent) => {
     event?.preventDefault()
@@ -92,7 +116,10 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
       if (formData.type === 'pat' && credential?.token && !tokenEdited) {
         dataToSave.token = credential.token
       }
-      await onSave(dataToSave)
+      await onSave(dataToSave, {
+        makeDefault: isGithubPat && makeDefault,
+        repoIds: isGithubPat ? selectedRepoIds : [],
+      })
       setFormData({ name: '', host: '', type: 'pat', token: '', username: '', sshPrivateKey: '', passphrase: '' })
       onOpenChange(false)
     } catch {
@@ -237,6 +264,42 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
                     autoComplete="off"
                   />
                 </div>
+
+                {isGithubPat && (
+                  <div className="space-y-3 rounded-lg border border-border p-3">
+                    <div className="flex items-start gap-2">
+                      <Checkbox
+                        id="cred-default-github-token"
+                        checked={makeDefault}
+                        onCheckedChange={(checked) => setMakeDefault(checked === true)}
+                        disabled={isSaving}
+                      />
+                      <div className="space-y-1">
+                        <Label htmlFor="cred-default-github-token">Use as default GitHub token</Label>
+                        <p className="text-xs text-muted-foreground">
+                          Used for GH_TOKEN/GITHUB_TOKEN unless a repository below overrides it.
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label>Use for specific repositories</Label>
+                      {repos.length === 0 ? (
+                        <p className="text-xs text-muted-foreground">No repositories available.</p>
+                      ) : (
+                        <MultiSelect
+                          value={selectedRepoIds.map(String)}
+                          onChange={(values) => setSelectedRepoIds(values.map(Number))}
+                          options={repoOptions}
+                          placeholder="Select repositories..."
+                          searchPlaceholder="Search repositories..."
+                          emptyMessage="No repositories found"
+                          disabled={isSaving}
+                        />
+                      )}
+                    </div>
+                  </div>
+                )}
               </>
             ) : (
               <>
@@ -336,7 +399,7 @@ export function GitCredentialDialog({ open, onOpenChange, onSave, credential, is
             type="button"
             onClick={handleSubmit}
             disabled={isSaving || !formData.name.trim() || !formData.host.trim() ||
-                     (formData.type === 'pat' && !formData.token?.trim()) ||
+                     (formData.type === 'pat' && !formData.token?.trim() && !(credential?.token && !tokenEdited)) ||
                      (formData.type === 'ssh' && !formData.sshPrivateKey?.trim())}
             className="flex-1 sm:flex-none"
           >

--- a/frontend/src/components/settings/GitSettings.tsx
+++ b/frontend/src/components/settings/GitSettings.tsx
@@ -1,27 +1,41 @@
 import { useState, useEffect } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useSettings } from '@/hooks/useSettings'
 import { Loader2, Plus, Trash2, Save, User, Key, Pencil } from 'lucide-react'
 import { showToast } from '@/lib/toast'
-import { GitCredentialDialog } from './GitCredentialDialog'
+import { GitCredentialDialog, type GitCredentialSaveOptions } from './GitCredentialDialog'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import type { GitCredential, GitIdentity } from '@/api/types/settings'
+import { listRepos, updateRepoGitCredential } from '@/api/repos'
+
+function ensureCredentialId(credential: GitCredential): GitCredential {
+  return credential.id ? credential : { ...credential, id: crypto.randomUUID() }
+}
 
 export function GitSettings() {
   const { preferences, isLoading, updateSettingsAsync, isUpdating } = useSettings()
+  const queryClient = useQueryClient()
   const [gitCredentials, setGitCredentials] = useState<GitCredential[]>([])
   const [gitIdentity, setGitIdentity] = useState<GitIdentity>({ name: '', email: '' })
+  const [defaultGitCredentialId, setDefaultGitCredentialId] = useState<string | undefined>()
   const [isSaving, setIsSaving] = useState(false)
   const [hasChanges, setHasChanges] = useState(false)
   const [isCredentialDialogOpen, setIsCredentialDialogOpen] = useState(false)
   const [editingCredentialIndex, setEditingCredentialIndex] = useState<number | null>(null)
+
+  const { data: repos = [] } = useQuery({
+    queryKey: ['repos'],
+    queryFn: listRepos,
+  })
 
 
   useEffect(() => {
     if (preferences) {
       setGitCredentials(preferences.gitCredentials || [])
       setGitIdentity(preferences.gitIdentity || { name: '', email: '' })
+      setDefaultGitCredentialId(preferences.defaultGitCredentialId)
       setHasChanges(false)
     }
   }, [preferences])
@@ -54,20 +68,37 @@ export function GitSettings() {
     removeCredential(index)
   }
 
-  const saveCredential = async (credential: GitCredential) => {
+  const syncRepoAssignments = async (credentialId: string, repoIds: number[]) => {
+    const selectedRepoIds = new Set(repoIds)
+    const affectedRepos = repos.filter((repo) => selectedRepoIds.has(repo.id) || repo.gitCredentialId === credentialId)
+
+    await Promise.all(
+      affectedRepos.map((repo) => updateRepoGitCredential(
+        repo.id,
+        selectedRepoIds.has(repo.id) ? credentialId : undefined
+      ))
+    )
+    await queryClient.invalidateQueries({ queryKey: ['repos'] })
+  }
+
+  const saveCredential = async (credential: GitCredential, options: GitCredentialSaveOptions) => {
     let newCredentials: GitCredential[]
+    const nextCredential = ensureCredentialId(credential)
+    const nextDefaultGitCredentialId = options.makeDefault ? nextCredential.id : defaultGitCredentialId === nextCredential.id ? undefined : defaultGitCredentialId
 
     if (editingCredentialIndex !== null) {
       newCredentials = [...gitCredentials]
-      newCredentials[editingCredentialIndex] = credential
+      newCredentials[editingCredentialIndex] = nextCredential
     } else {
-      newCredentials = [...gitCredentials, credential]
+      newCredentials = [...gitCredentials, nextCredential]
     }
 
     setGitCredentials(newCredentials)
+    setDefaultGitCredentialId(nextDefaultGitCredentialId)
     
     try {
-      await updateSettingsAsync({ gitCredentials: newCredentials, gitIdentity })
+      await updateSettingsAsync({ gitCredentials: newCredentials, defaultGitCredentialId: nextDefaultGitCredentialId, gitIdentity })
+      await syncRepoAssignments(nextCredential.id!, options.repoIds)
       showToast.success('Credential saved')
     } catch {
       showToast.error('Failed to save credential')
@@ -75,11 +106,19 @@ export function GitSettings() {
   }
 
   const removeCredential = async (index: number) => {
+    const removedCredentialId = gitCredentials[index]?.id
     const newCredentials = gitCredentials.filter((_, i) => i !== index)
+    const nextDefaultGitCredentialId = newCredentials.some((credential) => credential.id === defaultGitCredentialId)
+      ? defaultGitCredentialId
+      : undefined
     setGitCredentials(newCredentials)
+    setDefaultGitCredentialId(nextDefaultGitCredentialId)
 
     try {
-      await updateSettingsAsync({ gitCredentials: newCredentials, gitIdentity })
+      await updateSettingsAsync({ gitCredentials: newCredentials, defaultGitCredentialId: nextDefaultGitCredentialId, gitIdentity })
+      if (removedCredentialId) {
+        await syncRepoAssignments(removedCredentialId, [])
+      }
       showToast.success('Credential deleted')
     } catch {
       showToast.error('Failed to delete credential')
@@ -96,7 +135,7 @@ export function GitSettings() {
     setIsSaving(true)
     try {
       showToast.loading('Saving git configuration...', { id: 'git-config' })
-      const result = await updateSettingsAsync({ gitCredentials, gitIdentity })
+      const result = await updateSettingsAsync({ gitCredentials, defaultGitCredentialId, gitIdentity })
       setHasChanges(false)
       if (result.reloadError) {
         showToast.success('Git configuration saved (server reload pending)', { id: 'git-config' })
@@ -206,10 +245,10 @@ export function GitSettings() {
                >
                  <Plus className="h-4 w-4 mr-2" />
                  Add
-               </Button>
-             </div>
+                </Button>
+              </div>
 
-             {gitCredentials.length === 0 ? (
+              {gitCredentials.length === 0 ? (
                <div className="rounded-lg border border-dashed border-border p-4 text-center">
                  <p className="text-sm text-muted-foreground">
                    No credentials configured. Click "Add" to add credentials.
@@ -279,13 +318,18 @@ export function GitSettings() {
          </div>
        </div>
 
-       <GitCredentialDialog
+        <GitCredentialDialog
          open={isCredentialDialogOpen}
          onOpenChange={setIsCredentialDialogOpen}
-         onSave={saveCredential}
-         credential={editingCredentialIndex !== null ? gitCredentials[editingCredentialIndex] : undefined}
-         isSaving={isSaving || isUpdating}
-       />
+          onSave={saveCredential}
+          credential={editingCredentialIndex !== null ? gitCredentials[editingCredentialIndex] : undefined}
+          repos={repos}
+          assignedRepoIds={editingCredentialIndex !== null && gitCredentials[editingCredentialIndex]?.id
+            ? repos.filter((repo) => repo.gitCredentialId === gitCredentials[editingCredentialIndex]?.id).map((repo) => repo.id)
+            : []}
+          isDefault={editingCredentialIndex !== null && !!gitCredentials[editingCredentialIndex]?.id && defaultGitCredentialId === gitCredentials[editingCredentialIndex]?.id}
+          isSaving={isSaving || isUpdating}
+        />
     </div>
   )
 }

--- a/frontend/src/components/ui/multi-select.tsx
+++ b/frontend/src/components/ui/multi-select.tsx
@@ -13,6 +13,8 @@ interface MultiSelectProps {
   onChange: (values: string[]) => void
   options: MultiSelectOption[]
   placeholder?: string
+  searchPlaceholder?: string
+  emptyMessage?: string
   disabled?: boolean
   className?: string
 }
@@ -22,6 +24,8 @@ export function MultiSelect({
   onChange,
   options,
   placeholder = 'Select...',
+  searchPlaceholder = 'Search...',
+  emptyMessage = 'No options found',
   disabled = false,
   className,
 }: MultiSelectProps) {
@@ -167,7 +171,7 @@ export function MultiSelect({
               value={search}
               onChange={e => setSearch(e.target.value)}
               onKeyDown={handleInputKeyDown}
-              placeholder="Search skills..."
+              placeholder={searchPlaceholder}
               className={cn(
                 'flex h-8 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors',
                 'placeholder:text-muted-foreground',
@@ -177,7 +181,7 @@ export function MultiSelect({
           </div>
           <div className="max-h-52 overflow-y-auto" role="listbox">
             {filteredOptions.length === 0 ? (
-              <div className="px-3 py-4 text-center text-sm text-muted-foreground">No skills found</div>
+              <div className="px-3 py-4 text-center text-sm text-muted-foreground">{emptyMessage}</div>
             ) : (
               filteredOptions.map((option, index) => {
                 const isSelected = value.includes(option.value)

--- a/frontend/src/lib/htmlArtifacts.test.ts
+++ b/frontend/src/lib/htmlArtifacts.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from 'vitest'
+import {
+  isHtmlPath,
+  normalizeWorkspaceFilePath,
+  createHtmlArtifact,
+  getArtifactTitle,
+} from './htmlArtifacts'
+
+describe('isHtmlPath', () => {
+  it('returns true for .html paths', () => {
+    expect(isHtmlPath('repo/report.html')).toBe(true)
+  })
+
+  it('returns true for .HTM paths (case-insensitive)', () => {
+    expect(isHtmlPath('page.HTM')).toBe(true)
+    expect(isHtmlPath('page.Htm')).toBe(true)
+  })
+
+  it('returns false for .tsx paths', () => {
+    expect(isHtmlPath('component.tsx')).toBe(false)
+  })
+
+  it('returns false for .md paths', () => {
+    expect(isHtmlPath('readme.md')).toBe(false)
+  })
+
+  it('returns false for missing path', () => {
+    expect(isHtmlPath(undefined)).toBe(false)
+    expect(isHtmlPath('')).toBe(false)
+  })
+
+  it('ignores query strings and hash fragments', () => {
+    expect(isHtmlPath('index.html?raw=true')).toBe(true)
+    expect(isHtmlPath('index.html#section')).toBe(true)
+    expect(isHtmlPath('page.htm?query=1#hash')).toBe(true)
+  })
+})
+
+describe('normalizeWorkspaceFilePath', () => {
+  it('strips workspace repos path prefix', () => {
+    const result = normalizeWorkspaceFilePath(
+      '/workspace/repos/my-repo/dist/index.html',
+      '/workspace/repos/my-repo',
+    )
+    expect(result).toBe('my-repo/dist/index.html')
+  })
+
+  it('returns non-matching absolute paths unchanged', () => {
+    const result = normalizeWorkspaceFilePath(
+      '/some/other/path/file.html',
+      '/workspace/repos/my-repo',
+    )
+    expect(result).toBe('/some/other/path/file.html')
+  })
+
+  it('returns relative paths unchanged', () => {
+    const result = normalizeWorkspaceFilePath('relative/path.html', '/workspace/repos/my-repo')
+    expect(result).toBe('relative/path.html')
+  })
+
+  it('returns path unchanged when repoFullPath is missing', () => {
+    const result = normalizeWorkspaceFilePath('/workspace/repos/my-repo/file.html')
+    expect(result).toBe('/workspace/repos/my-repo/file.html')
+  })
+})
+
+describe('createHtmlArtifact', () => {
+  it('creates an inline artifact with required html', () => {
+    const artifact = createHtmlArtifact({ source: 'inline', html: '<h1>Hello</h1>' })
+    expect(artifact.source).toBe('inline')
+    expect(artifact.html).toBe('<h1>Hello</h1>')
+    expect(artifact.id).toBeTruthy()
+    expect(artifact.title).toBe('Untitled Artifact')
+  })
+
+  it('creates a file artifact with required path', () => {
+    const artifact = createHtmlArtifact({ source: 'file', path: 'my-repo/dist/index.html' })
+    expect(artifact.source).toBe('file')
+    expect(artifact.path).toBe('my-repo/dist/index.html')
+    expect(artifact.id).toBeTruthy()
+    expect(artifact.title).toBe('index')
+  })
+
+  it('uses provided title', () => {
+    const artifact = createHtmlArtifact({
+      source: 'inline',
+      html: '<h1>Hello</h1>',
+      title: 'My Artifact',
+    })
+    expect(artifact.title).toBe('My Artifact')
+  })
+
+  it('throws when path is missing for file artifact', () => {
+    expect(() => createHtmlArtifact({ source: 'file' })).toThrow('path is required')
+  })
+
+  it('throws when html is missing for inline artifact', () => {
+    expect(() => createHtmlArtifact({ source: 'inline' })).toThrow('html is required')
+  })
+})
+
+describe('handleFileClick path detection (normalize + isHtml combo)', () => {
+  it('classifies normalized .html path as artifact', () => {
+    const path = normalizeWorkspaceFilePath(
+      '/workspace/repos/my-repo/dist/index.html',
+      '/workspace/repos/my-repo',
+    )
+    expect(path).toBe('my-repo/dist/index.html')
+    expect(isHtmlPath(path)).toBe(true)
+  })
+
+  it('classifies normalized .htm path as artifact', () => {
+    const path = normalizeWorkspaceFilePath(
+      '/workspace/repos/my-repo/public/page.htm',
+      '/workspace/repos/my-repo',
+    )
+    expect(path).toBe('my-repo/public/page.htm')
+    expect(isHtmlPath(path)).toBe(true)
+  })
+
+  it('does not classify non-HTML path as artifact', () => {
+    const path = normalizeWorkspaceFilePath(
+      '/workspace/repos/my-repo/src/app.tsx',
+      '/workspace/repos/my-repo',
+    )
+    expect(path).toBe('my-repo/src/app.tsx')
+    expect(isHtmlPath(path)).toBe(false)
+  })
+
+  it('does not classify relative non-HTML path as artifact', () => {
+    expect(isHtmlPath(normalizeWorkspaceFilePath('src/utils.ts'))).toBe(false)
+  })
+
+  it('classifies .html path without repo prefix as artifact', () => {
+    const path = normalizeWorkspaceFilePath('some-folder/index.html')
+    expect(isHtmlPath(path)).toBe(true)
+  })
+})
+
+describe('getArtifactTitle', () => {
+  it('returns file name without extension for .html paths', () => {
+    expect(getArtifactTitle('my-repo/dist/index.html')).toBe('index')
+  })
+
+  it('returns file name without extension for .htm paths', () => {
+    expect(getArtifactTitle('page.htm')).toBe('page')
+  })
+
+  it('returns last segment for non-HTML paths', () => {
+    expect(getArtifactTitle('some/path/file.txt')).toBe('file.txt')
+  })
+
+  it('returns Untitled Artifact for undefined', () => {
+    expect(getArtifactTitle(undefined)).toBe('Untitled Artifact')
+  })
+})

--- a/frontend/src/lib/htmlArtifacts.test.ts
+++ b/frontend/src/lib/htmlArtifacts.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeWorkspaceFilePath,
   createHtmlArtifact,
   getArtifactTitle,
+  normalizeHtmlPreviewDocument,
 } from './htmlArtifacts'
 
 describe('isHtmlPath', () => {
@@ -152,5 +153,30 @@ describe('getArtifactTitle', () => {
 
   it('returns Untitled Artifact for undefined', () => {
     expect(getArtifactTitle(undefined)).toBe('Untitled Artifact')
+  })
+})
+
+describe('normalizeHtmlPreviewDocument', () => {
+  it('adds viewport meta and sizing style to html fragments', () => {
+    const result = normalizeHtmlPreviewDocument('<h1>Hello</h1>')
+
+    expect(result).toContain('name="viewport"')
+    expect(result).toContain('opencode-html-preview-sizing')
+    expect(result).toContain('overflow-y:auto!important')
+    expect(result).toContain('<h1>Hello</h1>')
+  })
+
+  it('does not duplicate an existing viewport meta tag', () => {
+    const result = normalizeHtmlPreviewDocument('<head><meta name="viewport" content="width=device-width"></head>')
+
+    expect(result.match(/name="viewport"/g)).toHaveLength(1)
+    expect(result).toContain('opencode-html-preview-sizing')
+  })
+
+  it('inserts preview sizing before an existing closing head tag', () => {
+    const result = normalizeHtmlPreviewDocument('<html><head><title>Demo</title></head><body>Demo</body></html>')
+
+    expect(result).toContain('<title>Demo</title><meta name="viewport"')
+    expect(result).toContain('opencode-html-preview-sizing')
   })
 })

--- a/frontend/src/lib/htmlArtifacts.ts
+++ b/frontend/src/lib/htmlArtifacts.ts
@@ -14,6 +14,12 @@ export interface OpenHtmlArtifactInput {
 }
 
 const HTML_EXTENSIONS = new Set(['.html', '.htm'])
+const HTML_PREVIEW_STYLE_ID = 'opencode-html-preview-sizing'
+const HTML_PREVIEW_VIEWPORT_META = '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">'
+const HTML_PREVIEW_SIZING_STYLE = `<style id="${HTML_PREVIEW_STYLE_ID}">html,body{width:100%;max-width:100%;min-width:0;min-height:100%;height:auto!important;margin:0;overflow-x:hidden!important;overflow-y:auto!important;}#root,#__next{min-height:100%;height:auto!important;max-width:100%;overflow-x:hidden;}*,*::before,*::after{box-sizing:border-box;}img,svg,video,canvas{max-width:100%;}</style>`
+const VIEWPORT_META_PATTERN = /<meta\s+[^>]*name=["']viewport["'][^>]*>/i
+const HEAD_OPEN_PATTERN = /<head([^>]*)>/i
+const HEAD_CLOSE_PATTERN = /<\/head>/i
 
 export function isHtmlPath(path: string | undefined): boolean {
   if (!path) return false
@@ -40,6 +46,24 @@ export function createHtmlArtifact(input: OpenHtmlArtifactInput): HtmlArtifact {
   const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
   const title = input.title ?? getArtifactTitle(input.source === 'file' ? input.path : undefined)
   return { id, title, source: input.source, html: input.html, path: input.path }
+}
+
+export function normalizeHtmlPreviewDocument(html: string): string {
+  const viewportMeta = VIEWPORT_META_PATTERN.test(html) ? '' : HTML_PREVIEW_VIEWPORT_META
+  const sizingStyle = html.includes(HTML_PREVIEW_STYLE_ID) ? '' : HTML_PREVIEW_SIZING_STYLE
+  const headContent = `${viewportMeta}${sizingStyle}`
+
+  if (!headContent) return html
+
+  if (HEAD_CLOSE_PATTERN.test(html)) {
+    return html.replace(HEAD_CLOSE_PATTERN, `${headContent}</head>`)
+  }
+
+  if (HEAD_OPEN_PATTERN.test(html)) {
+    return html.replace(HEAD_OPEN_PATTERN, `<head$1>${headContent}`)
+  }
+
+  return `<head>${headContent}</head>${html}`
 }
 
 export function normalizeWorkspaceFilePath(filePath: string, repoFullPath?: string): string {

--- a/frontend/src/lib/htmlArtifacts.ts
+++ b/frontend/src/lib/htmlArtifacts.ts
@@ -1,0 +1,52 @@
+export interface HtmlArtifact {
+  id: string
+  title: string
+  source: 'inline' | 'file'
+  html?: string
+  path?: string
+}
+
+export interface OpenHtmlArtifactInput {
+  title?: string
+  source: 'inline' | 'file'
+  html?: string
+  path?: string
+}
+
+const HTML_EXTENSIONS = new Set(['.html', '.htm'])
+
+export function isHtmlPath(path: string | undefined): boolean {
+  if (!path) return false
+  const clean = path.split(/[?#]/)[0].toLowerCase()
+  return HTML_EXTENSIONS.has(clean.slice(clean.lastIndexOf('.')))
+}
+
+export function getArtifactTitle(pathOrTitle: string | undefined): string {
+  if (!pathOrTitle) return 'Untitled Artifact'
+  const lastSegment = pathOrTitle.split('/').pop() || pathOrTitle
+  if (isHtmlPath(lastSegment)) {
+    return lastSegment.slice(0, lastSegment.lastIndexOf('.'))
+  }
+  return lastSegment
+}
+
+export function createHtmlArtifact(input: OpenHtmlArtifactInput): HtmlArtifact {
+  if (input.source === 'file' && !input.path) {
+    throw new Error('path is required for file artifacts')
+  }
+  if (input.source === 'inline' && !input.html) {
+    throw new Error('html is required for inline artifacts')
+  }
+  const id = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  const title = input.title ?? getArtifactTitle(input.source === 'file' ? input.path : undefined)
+  return { id, title, source: input.source, html: input.html, path: input.path }
+}
+
+export function normalizeWorkspaceFilePath(filePath: string, repoFullPath?: string): string {
+  if (!filePath.startsWith('/') || !repoFullPath) return filePath
+  const workspaceReposPath = repoFullPath.substring(0, repoFullPath.lastIndexOf('/'))
+  if (filePath.startsWith(`${workspaceReposPath}/`)) {
+    return filePath.substring(workspaceReposPath.length + 1)
+  }
+  return filePath
+}

--- a/frontend/src/pages/SessionDetail.tsx
+++ b/frontend/src/pages/SessionDetail.tsx
@@ -52,6 +52,9 @@ import { SessionTodoDisplay } from "@/components/message/SessionTodoDisplay";
 import { useDialogParam } from "@/hooks/useDialogParam";
 import { useSidebarAction } from "@/hooks/useSidebarAction";
 import { SessionMoreButton } from "@/components/navigation/SessionMoreButton";
+import { HtmlArtifactPanel } from "@/components/html-preview/HtmlArtifactPanel";
+import type { HtmlArtifact, OpenHtmlArtifactInput } from '@/lib/htmlArtifacts'
+import { createHtmlArtifact, isHtmlPath, normalizeWorkspaceFilePath } from '@/lib/htmlArtifacts'
 
 const compareMessageIds = (id1: string, id2: string): number => {
   const num1 = parseInt(id1, 10)
@@ -84,6 +87,8 @@ export function SessionDetail() {
   const [showScrollButton, setShowScrollButton] = useState(false);
   const [hasPromptContent, setHasPromptContent] = useState(false);
   const [minimizedQuestion, setMinimizedQuestion] = useState<QuestionRequest | null>(null);
+  const [htmlArtifact, setHtmlArtifact] = useState<HtmlArtifact | null>(null);
+  const [htmlArtifactFullscreen, setHtmlArtifactFullscreen] = useState(false);
 
   const isMobile = useMobile();
   const { keyboardHeight } = useVisualViewport();
@@ -200,6 +205,28 @@ export function SessionDetail() {
   
   const handleRestoreQuestion = useCallback(() => {
     setMinimizedQuestion(null)
+  }, [])
+
+  const handleHtmlArtifactOpen = useCallback((input: OpenHtmlArtifactInput) => {
+    try {
+      const normalizedPath = input.source === 'file' && input.path
+        ? normalizeWorkspaceFilePath(input.path, repo?.fullPath)
+        : input.path
+      const artifact = createHtmlArtifact({ ...input, path: normalizedPath })
+      setHtmlArtifact(artifact)
+      setHtmlArtifactFullscreen(isMobile)
+    } catch {
+      showToast.error('Failed to create artifact')
+    }
+  }, [isMobile, repo?.fullPath])
+
+  const handleHtmlArtifactClose = useCallback(() => {
+    setHtmlArtifact(null)
+    setHtmlArtifactFullscreen(false)
+  }, [])
+
+  const handleHtmlArtifactFullscreenToggle = useCallback(() => {
+    setHtmlArtifactFullscreen(v => !v)
   }, [])
 
   useEffect(() => {
@@ -336,22 +363,21 @@ export function SessionDetail() {
     },
   });
 
-  
-
   const handleFileClick = useCallback((filePath: string) => {
-    let pathToOpen = filePath
-    
-    if (filePath.startsWith('/') && repo?.fullPath) {
-      const workspaceReposPath = repo.fullPath.substring(0, repo.fullPath.lastIndexOf('/'))
-      
-      if (filePath.startsWith(workspaceReposPath + '/')) {
-        pathToOpen = filePath.substring(workspaceReposPath.length + 1)
-      }
+    const pathToOpen = normalizeWorkspaceFilePath(filePath, repo?.fullPath)
+
+    if (isHtmlPath(pathToOpen)) {
+      handleHtmlArtifactOpen({
+        source: 'file',
+        path: pathToOpen,
+        title: pathToOpen.split('/').pop() || 'HTML artifact',
+      })
+      return
     }
-    
+
     setSelectedFilePath(pathToOpen)
     setFileBrowserOpen(true)
-  }, [repo?.fullPath, setFileBrowserOpen]);
+  }, [repo?.fullPath, handleHtmlArtifactOpen, setFileBrowserOpen]);
 
   const handleSessionTitleUpdate = useCallback((newTitle: string) => {
     if (sessionId) {
@@ -399,10 +425,6 @@ export function SessionDetail() {
   const handleClearPrompt = useCallback(() => {
     promptInputRef.current?.clearPrompt()
   }, []);
-
-  
-
-  
 
   if (!sessionId) {
     return <Navigate to="/" replace />;
@@ -480,29 +502,31 @@ export function SessionDetail() {
         </div>
       </div>
 
-      <div className="relative flex-1 overflow-hidden flex flex-col">
-        <div key={sessionId} ref={messageContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain [mask-image:linear-gradient(to_bottom,transparent,black_16px,black)]" style={{ paddingBottom: promptOverlayHeight + inputBottomOffset + PROMPT_OVERLAY_CLEARANCE_PX }}>
-          {repoLoading || sessionLoading || messagesLoading ? (
-            <MessageSkeleton />
-          ) : opcodeUrl && repoDirectory ? (
-            <MessageThread 
-              opcodeUrl={opcodeUrl} 
-              sessionID={sessionId} 
-              directory={repoDirectory}
-              messages={messages}
-              onFileClick={handleFileClick}
-              onChildSessionClick={handleChildSessionClick}
-              onUndoMessage={handleUndoMessage}
-              model={modelString || undefined}
-            />
-          ) : null}
-        </div>
-        {opcodeUrl && repoDirectory && !isEditingMessage && (
-          <div
-            ref={promptOverlayRef}
-            className="absolute left-0 right-0 flex justify-center"
-            style={{ bottom: inputBottomOffset }}
-          >
+      <div className="relative flex-1 overflow-hidden flex flex-row">
+        <div className="relative flex-1 min-w-0 overflow-hidden flex flex-col">
+          <div key={sessionId} ref={messageContainerRef} className="flex-1 overflow-y-auto overflow-x-hidden overscroll-contain [mask-image:linear-gradient(to_bottom,transparent,black_16px,black)]" style={{ paddingBottom: promptOverlayHeight + inputBottomOffset + PROMPT_OVERLAY_CLEARANCE_PX }}>
+            {repoLoading || sessionLoading || messagesLoading ? (
+              <MessageSkeleton />
+            ) : opcodeUrl && repoDirectory ? (
+              <MessageThread 
+                opcodeUrl={opcodeUrl} 
+                sessionID={sessionId} 
+                directory={repoDirectory}
+                messages={messages}
+                onFileClick={handleFileClick}
+                onChildSessionClick={handleChildSessionClick}
+                onUndoMessage={handleUndoMessage}
+                onHtmlArtifactOpen={handleHtmlArtifactOpen}
+                model={modelString || undefined}
+              />
+            ) : null}
+          </div>
+          {opcodeUrl && repoDirectory && !isEditingMessage && (
+            <div
+              ref={promptOverlayRef}
+              className="absolute left-0 right-0 flex justify-center"
+              style={{ bottom: inputBottomOffset }}
+            >
             <div className="relative w-[94%] md:max-w-4xl">
               <div className="absolute -top-9 right-0 z-50 flex flex-col items-end gap-2">
                 {ttsEnabled && !hasPromptContent && !isSessionActive && latestPlayableAssistant && (
@@ -567,6 +591,16 @@ export function SessionDetail() {
             </div>
           </div>
         )}
+        </div>
+        {htmlArtifact && !htmlArtifactFullscreen && !isMobile && (
+          <HtmlArtifactPanel
+            artifact={htmlArtifact}
+            isFullscreen={false}
+            isMobile={false}
+            onClose={handleHtmlArtifactClose}
+            onToggleFullscreen={handleHtmlArtifactFullscreenToggle}
+          />
+        )}
       </div>
 
       {/* Sessions Dialog */}
@@ -597,6 +631,16 @@ export function SessionDetail() {
         repoId={repoId}
         initialSelectedFile={selectedFilePath}
       />
+
+      {htmlArtifact && (htmlArtifactFullscreen || isMobile) && (
+        <HtmlArtifactPanel
+          artifact={htmlArtifact}
+          isFullscreen={true}
+          isMobile={isMobile}
+          onClose={handleHtmlArtifactClose}
+          onToggleFullscreen={handleHtmlArtifactFullscreenToggle}
+        />
+      )}
 
       <RepoLspDialog
         open={lspDialogOpen}

--- a/shared/src/schemas/repo.ts
+++ b/shared/src/schemas/repo.ts
@@ -15,6 +15,7 @@ export const RepoSchema = z.object({
   lastPulled: z.number().optional(),
   lastAccessedAt: z.number().optional(),
   openCodeConfigName: z.string().optional(),
+  gitCredentialId: z.string().optional(),
   isWorktree: z.boolean().optional(),
   isLocal: z.boolean().optional(),
 })

--- a/shared/src/schemas/settings.ts
+++ b/shared/src/schemas/settings.ts
@@ -83,6 +83,7 @@ export const DEFAULT_KEYBOARD_SHORTCUTS: Record<string, string> = {
 };
 
 export const GitCredentialSchema = z.object({
+  id: z.string().optional(),
   name: z.string(),
   host: z.string(),
   type: z.enum(['pat', 'ssh']).default('pat'),
@@ -146,6 +147,7 @@ export const UserPreferencesSchema = z.object({
   keyboardShortcuts: z.record(z.string(), z.string()),
   customCommands: z.array(CustomCommandSchema),
   gitCredentials: z.array(GitCredentialSchema).optional(),
+  defaultGitCredentialId: z.string().optional(),
   gitIdentity: GitIdentitySchema.optional(),
   tts: TTSConfigSchema.optional(),
   stt: STTConfigSchema.optional(),
@@ -197,6 +199,7 @@ export const DEFAULT_USER_PREFERENCES = {
   customCommands: [],
   customAgents: [],
   gitCredentials: [] as GitCredential[],
+  defaultGitCredentialId: undefined as string | undefined,
   gitIdentity: DEFAULT_GIT_IDENTITY,
   tts: DEFAULT_TTS_CONFIG,
   stt: DEFAULT_STT_CONFIG,


### PR DESCRIPTION
Add a preview system for HTML artifacts generated by the assistant — both inline HTML content and file-based .html outputs from the Write tool. Includes a sandboxed iframe preview, backend file-serving endpoint with CSP headers, and fullscreen/side-panel modes.

Changes:
- New GET /api/files/preview/* backend route with sandboxed CSP headers for safe HTML/SVG rendering in iframes
- HtmlArtifactPanel component: side-panel (desktop) / fullscreen sheet (mobile)
- HtmlPreviewFrame: sandboxed iframe (src for file artifacts, srcdoc for inline)
- "Preview HTML" button in CodePreview for .html file blocks
- TextPart/ToolCallPart wired to surface HTML artifacts from Write-tool output
- htmlArtifacts.ts utility: artifact creation, path normalization, title extraction
- SessionDetail state management for artifact open/fullscreen lifecycle
- Tests for all new components and utilities

Validation:
- pnpm lint