### PR TITLE
fix(mobile): distinguish worktrees in repo quick switch sheet by branch

### DIFF
--- a/frontend/src/components/navigation/RepoQuickSwitchSheet.test.tsx
+++ b/frontend/src/components/navigation/RepoQuickSwitchSheet.test.tsx
@@ -110,6 +110,53 @@ describe('RepoQuickSwitchSheet', () => {
     })
   })
 
+  it('distinguishes worktrees of the same repo by branch', async () => {
+    vi.mocked(listRepos).mockResolvedValue([
+      {
+        id: 1,
+        repoUrl: 'https://github.com/test/repo1.git',
+        localPath: '/path/to/repo1',
+        sourcePath: null,
+        currentBranch: 'main',
+        isLocal: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        id: 2,
+        repoUrl: 'https://github.com/test/repo1.git',
+        localPath: '/path/to/repo1/.worktrees/feature-a',
+        sourcePath: null,
+        currentBranch: 'feature-a',
+        isWorktree: true,
+        isLocal: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+      {
+        id: 3,
+        repoUrl: 'https://github.com/test/repo1.git',
+        localPath: '/path/to/repo1/.worktrees/feature-b',
+        sourcePath: null,
+        currentBranch: 'feature-b',
+        isWorktree: true,
+        isLocal: false,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ])
+    const handleClose = vi.fn()
+    render(
+      <RepoQuickSwitchSheet isOpen onClose={handleClose} />,
+      { wrapper: createWrapper() },
+    )
+    await waitFor(() => {
+      expect(screen.getAllByText('repo1')).toHaveLength(3)
+      expect(screen.getByText('feature-a')).toBeInTheDocument()
+      expect(screen.getByText('feature-b')).toBeInTheDocument()
+    })
+  })
+
   it('does not show assistant as a repo option', async () => {
     vi.mocked(listRepos).mockResolvedValue([
       {

--- a/frontend/src/components/navigation/RepoQuickSwitchSheet.tsx
+++ b/frontend/src/components/navigation/RepoQuickSwitchSheet.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import { cn, getRepoDisplayName } from '@/lib/utils'
 import { listRepos } from '@/api/repos'
 import { AddRepoDialog } from '@/components/repo/AddRepoDialog'
-import { FolderGit2, Check, Plus } from 'lucide-react'
+import { FolderGit2, Check, Plus, GitBranch } from 'lucide-react'
 import { useUrlParams } from '@/hooks/useUrlParams'
 import { ASSISTANT_REPO_ID } from '@opencode-manager/shared/utils'
 import { getAssistantPath, isAssistantPath } from '@/lib/navigation'
@@ -123,6 +123,7 @@ export function RepoQuickSwitchSheet({ isOpen, onClose }: RepoQuickSwitchSheetPr
           <div className="flex flex-col gap-2">
             {filteredRepos.map((repo) => {
               const isActive = repo.id === activeRepoId
+              const branchToDisplay = repo.currentBranch || repo.branch
               return (
                 <button
                   key={repo.id}
@@ -146,8 +147,21 @@ export function RepoQuickSwitchSheet({ isOpen, onClose }: RepoQuickSwitchSheetPr
                       <FolderGit2 className="h-4 w-4" />
                     </div>
                   </div>
-                  <div className="flex-1 min-w-0 font-medium text-sm text-foreground truncate">
-                    {getRepoDisplayName(repo)}
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-sm text-foreground truncate">
+                      {getRepoDisplayName(repo)}
+                    </div>
+                    {branchToDisplay && (
+                      <div
+                        className={cn(
+                          'flex items-center gap-1 text-xs',
+                          repo.isWorktree ? 'text-purple-400' : 'text-muted-foreground',
+                        )}
+                      >
+                        <GitBranch className="h-3 w-3 shrink-0" />
+                        <span className="truncate">{branchToDisplay}</span>
+                      </div>
+                    )}
                   </div>
                   {isActive && <Check className="h-4 w-4 text-primary flex-shrink-0" />}
                 </button>


### PR DESCRIPTION
## Problem

In the mobile repos quick switch sheet, a repository and its worktrees render as identical rows — the sheet only shows `getRepoDisplayName(repo)`, with no branch context. The main repo homepage (`RepoCard`) already disambiguates them with a branch sublabel.

## Fix

Mirror the homepage treatment in `RepoQuickSwitchSheet`:

- Show a `GitBranch` + branch sublabel under each repo name (`repo.currentBranch || repo.branch`)
- Style the sublabel purple (`text-purple-400`) for worktrees, muted for regular repos — same as homepage
- No backend/API changes needed: `listRepos` already returns `currentBranch`, `branch`, and `isWorktree`

## Testing

- New regression test: parent repo + two worktrees of the same repo all render, with distinct branch labels visible
- `vitest` for the sheet: 12 passed
- `pnpm lint:frontend` clean
- frontend `tsc -b --noEmit` clean

## How to test manually

Open the app on mobile, tap the Repos tab, and view a repo that has worktrees — each worktree row now shows its branch under the repo name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Repository quick switching now displays the active branch for each entry.
  * Worktrees sharing a repository are shown as separate entries with distinct branch styling.

* **Bug Fixes**
  * Improved clarity when switching between multiple worktrees from the same repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->